### PR TITLE
Revert "Update jaxb version to latest, removed an unnecessary dependency"

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -109,17 +109,22 @@
 		<dependency>
 			<groupId>javax.xml.bind</groupId>
 			<artifactId>jaxb-api</artifactId>
-			<version>2.3.1</version>
+			<version>2.2.11</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sun.xml.bind</groupId>
 			<artifactId>jaxb-core</artifactId>
-			<version>2.3.0.1</version>
+			<version>2.2.11</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sun.xml.bind</groupId>
 			<artifactId>jaxb-impl</artifactId>
-			<version>2.3.2</version>
+			<version>2.2.11</version>
+		</dependency>
+		<dependency>
+			<groupId>javax.activation</groupId>
+			<artifactId>activation</artifactId>
+			<version>1.1.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>


### PR DESCRIPTION
Reverts phoenixctms/ctsms#8

[ERROR] BUILD ERROR
[INFO] ------------------------------------------------------------------------
[INFO] Failed to resolve artifact.

Unable to get dependency information: Unable to read the metadata file for artifact 'com.sun.xml.bind:jaxb-core:jar': Cannot find parent: com.sun.xml.bind:jaxb-
bom-ext for project: com.sun.xml.bind.mvn:jaxb-parent:pom:null for project com.sun.xml.bind.mvn:jaxb-parent:pom:null
  com.sun.xml.bind:jaxb-core:jar:2.3.0.1

from the specified remote repositories:
  jboss-public (http://repository.jboss.org/nexus/content/groups/public-jboss),
  central (http://repo1.maven.org/maven2),
  maven-repo (http://repo1.maven.org/maven2),
  java.net-Public (https://maven.java.net/content/groups/public),
  prime-repo (http://repository.primefaces.org),
  download (http://download.java.net/maven/2)

Path to dependency:
        1) org.phoenixctms.ctsms:ctsms:pom:1.6.2