### PR TITLE
Correct definitions for JSF 2.1, Servlet 3.1

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -82,8 +82,8 @@
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<version>2.5</version>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>3.1.0</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/web/src/main/webapp/META-INF/templates/baseTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/baseTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/courseEntityTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/courseEntityTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/courseHomeTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/courseHomeTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/courseTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/courseTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/inputFieldEntityTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/inputFieldEntityTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/inputFieldHomeTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/inputFieldHomeTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/inputFieldTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/inputFieldTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/inventoryEntityTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/inventoryEntityTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/inventoryHomeTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/inventoryHomeTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/inventoryTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/inventoryTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/massMailEntityTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/massMailEntityTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/massMailHomeTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/massMailHomeTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/massMailTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/massMailTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/moduleTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/moduleTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/popupTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/popupTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/probandEntityTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/probandEntityTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/probandHomeTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/probandHomeTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/probandTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/probandTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/staffEntityTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/staffEntityTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/staffHomeTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/staffHomeTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/staffTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/staffTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/trialEntityTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/trialEntityTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/trialHomeTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/trialHomeTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/trialTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/trialTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/userEntityTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/userEntityTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/userHomeTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/userHomeTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/META-INF/templates/userTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/userTemplate.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="http://java.sun.com/jsf/facelets"

--- a/web/src/main/webapp/WEB-INF/ctsms-taglib.xml
+++ b/web/src/main/webapp/WEB-INF/ctsms-taglib.xml
@@ -19,8 +19,8 @@
 
 	<tag>
 		<tag-name>tagCloud</tag-name>
-		<description><![CDATA[]]></description>
 		<component>
+			<description><![CDATA[]]></description>
 			<component-type>ctsms.TagCloud</component-type>
 			<renderer-type>ctsms.TagCloud</renderer-type>
 		</component>
@@ -70,8 +70,8 @@
 	
 		<tag>
 		<tag-name>captcha</tag-name>
-		<description><![CDATA[Captcha is a form validation component based on Recaptcha API.]]></description>
 		<component>
+			<description><![CDATA[Captcha is a form validation component based on Recaptcha API.]]></description>
 			<component-type>ctsms.Captcha</component-type>
 			<renderer-type>ctsms.Captcha</renderer-type>
 		</component>

--- a/web/src/main/webapp/WEB-INF/faces-config.xml
+++ b/web/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<faces-config version="2.0" xmlns="http://java.sun.com/xml/ns/javaee"
- xmlns:xi="http://www.w3.org/2001/XInclude"
- xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd">
+ <faces-config xmlns="http://java.sun.com/xml/ns/javaee" 
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+          http://java.sun.com/xml/ns/javaee/web-facesconfig_2_1.xsd"
+          version="2.1">
  <!-- Settings for application -->
  <application>
   <locale-config>
@@ -76,25 +78,27 @@
   <!--        <el-resolver>
           org.springframework.web.jsf.el.SpringBeanFacesELResolver
         </el-resolver>  -->
-        
-        <default-validators>
-         <validator>
-  <validator-id>javax.faces.Bean</validator-id>
-  <validator-class>org.phoenixctms.ctsms.web.SkipBeanValidator</validator-class>
- </validator>
- <validator>
-  <validator-id>javax.faces.Required</validator-id>
-  <validator-class>org.phoenixctms.ctsms.web.SkipRequiredValidator</validator-class>
- </validator>
-        </default-validators>
+
+	<default-validators>
+		<validator-id>javax.faces.Bean</validator-id>
+		<validator-id>javax.faces.Required</validator-id>
+	</default-validators>
         
 
     <resource-handler>org.phoenixctms.ctsms.web.ResourceHandlerWrapper</resource-handler>
-
-        
         
  </application>
- 
+
+	<validator>
+		<validator-id>javax.faces.Bean</validator-id>
+		<validator-class>org.phoenixctms.ctsms.web.SkipBeanValidator</validator-class>
+	</validator>
+	<validator>
+		<validator-id>javax.faces.Required</validator-id>
+		<validator-class>org.phoenixctms.ctsms.web.SkipRequiredValidator</validator-class>
+	</validator>
+	
+	
   <lifecycle>
      <phase-listener>org.phoenixctms.ctsms.web.ResetInputAjaxActionListener</phase-listener>
  </lifecycle>

--- a/web/src/main/webapp/WEB-INF/web.xml
+++ b/web/src/main/webapp/WEB-INF/web.xml
@@ -288,6 +288,7 @@
 	        <http-only>true</http-only> 
 	        <secure>false</secure>
 	    </cookie-config>        
+        <tracking-mode>COOKIE</tracking-mode>
     </session-config>
     
     

--- a/web/src/main/webapp/WEB-INF/web.xml
+++ b/web/src/main/webapp/WEB-INF/web.xml
@@ -1,10 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<web-app xmlns="http://java.sun.com/xml/ns/javaee"
-    xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
-    id="ctsms"
-    version="2.5">
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee 
+		 http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
           
     <description>Clinical Trial Site Management System</description>
 
@@ -125,7 +124,6 @@
     <filter-mapping>
         <filter-name>PrimeFaces FileUpload Filter</filter-name>
         <servlet-name>Faces Servlet</servlet-name>
-        <load-on-startup>10</load-on-startup>
     </filter-mapping>
 
 
@@ -285,7 +283,6 @@
     
     <session-config>
         <session-timeout>60</session-timeout>
-        <tracking-mode>COOKIE</tracking-mode>
 	    <cookie-config>
 	        <path>/</path>                       
 	        <http-only>true</http-only> 
@@ -374,35 +371,10 @@
   <servlet>
     <servlet-name>Jersey REST Service</servlet-name>
     <servlet-class>com.sun.jersey.spi.container.servlet.ServletContainer</servlet-class>
-    <!--  <servlet-class>com.sun.jersey.impl.container.servlet.ServletAdaptor</servlet-class> -->
-     <!-- <init-param>
-      <param-name>com.sun.jersey.config.property.packages</param-name>
-      <param-value>org.phoenixctms.ctsms.web.jersey</param-value>
-      </init-param> -->
              <init-param>
             <param-name>javax.ws.rs.Application</param-name>
             <param-value>org.phoenixctms.ctsms.web.jersey.Application</param-value>
         </init-param> 
-           <!--  <init-param>
-         <param-name>com.sun.jersey.spi.container.ContainerRequestFilters</param-name>
-         <param-value>com.sun.jersey.api.container.filter.LoggingFilter</param-value>
-     </init-param>
-     <init-param>
-         <param-name>com.sun.jersey.spi.container.ContainerResponseFilters</param-name>
-         <param-value>com.sun.jersey.api.container.filter.LoggingFilter</param-value>
-     </init-param> -->
-    <!-- <param-name>com.sun.jersey.spi.container.ContainerRequestFilters</param-name>
-    <param-value>your.package.BasicAuthFilter</param-value> -->   
-    <!-- <init-param>
-            <param-name>com.sun.jersey.api.json.POJOMappingFeature</param-name>
-            <param-value>true</param-value>
-        </init-param> -->   
-        
-<!-- <init-param>
-            <param-name>com.sun.jersey.config.feature.Trace</param-name>
-            <param-value>true</param-value>
-        </init-param> -->
-    <load-on-startup>20</load-on-startup>
     <init-param>
         <param-name>com.sun.jersey.spi.container.ContainerResponseFilters</param-name>
         <param-value>org.phoenixctms.ctsms.web.jersey.provider.CORSFilter</param-value>
@@ -411,6 +383,7 @@
 	  <param-name>com.sun.jersey.spi.container.ContainerRequestFilters</param-name>
 	  <param-value>org.phoenixctms.ctsms.web.jersey.provider.TrustedHostFilter</param-value>
 	</init-param>    
+    <load-on-startup>20</load-on-startup>
   </servlet>
   <servlet-mapping>
     <servlet-name>Jersey REST Service</servlet-name>


### PR DESCRIPTION
- Apparently JSF 2.1 is used, so faces-config should adhere to it.
- Configuration items indicate that Servlet Api >= 3.0 is used and tomcat8 runs with Servlet 3.1, so make it explicit.  
- Fix a couple of ill-defined definitions, so that xsd schemas are satisfied.

What I'm unsure about: 

- [x] `filter-mapping` for primefaces upload servlet contained a `load-on-startup` element, which is expected to be part of an `servlet`. My guess is that this wasn't picked up at all, and so its not a problem to remove the element.
- [x] `validators` were defined in the the `default-validators` element, but should only be referenced there. Should they be active? 