### PR TITLE
Update all themes to 1.0.10 and use maven war 3.2.2

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -11,7 +11,7 @@
 	<packaging>war</packaging>
 	<name>Clinical Trial Site Management System Web</name>
 	<properties>
-		<theme.version>1.0.6</theme.version>
+		<theme.version>1.0.10</theme.version>
 		<jersey.version>1.19.4</jersey.version>
 	</properties>
 	<dependencies>
@@ -177,7 +177,7 @@
 			<artifactId>resources-codemirror</artifactId>
 			<version>0.7.0</version>
 		</dependency>
-
+		
 		<dependency>
 			<groupId>org.primefaces.themes</groupId>
 			<artifactId>afterdark</artifactId>
@@ -356,20 +356,21 @@
 		<dependency>
 			<groupId>org.primefaces.themes</groupId>
 			<artifactId>bootstrap</artifactId>
-			<version>1.0.8</version>
+			<version>${theme.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.primefaces.themes</groupId>
 			<artifactId>delta</artifactId>
-			<version>1.0.10</version>
+			<version>${theme.version}</version>
 		</dependency>
+		
 		<dependency>
 			<groupId>commons-fileupload</groupId>
 			<artifactId>commons-fileupload</artifactId>
 			<version>1.3.3</version>
 			<scope>runtime</scope>
 		</dependency>
-
+		
 	</dependencies>
 	<build>
 		<finalName>${application.id}-${project.version}</finalName>
@@ -415,7 +416,7 @@
 
 			<plugin>
 				<artifactId>maven-war-plugin</artifactId>
-				<version>2.1.1</version>
+				<version>3.2.2</version>
 			</plugin>
 			<plugin>
 				<groupId>org.andromda.maven.plugins</groupId>


### PR DESCRIPTION
- Use 1.0.10 for all themes. 
- Use current maven-war plugin. `pkgdiff` shows no change after updating to this plugin.