### PR TITLE
Compile warnings

### DIFF
--- a/core/src/main/java/org/phoenixctms/ctsms/js/FieldCalculation.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/js/FieldCalculation.java
@@ -34,6 +34,7 @@ import org.springframework.core.io.ClassPathResource;
 import jdk.nashorn.api.scripting.JSObject;
 
 //import sun.org.mozilla.javascript.internal.Scriptable;
+@SuppressWarnings("restriction")
 public class FieldCalculation {
 
 	private final static String ENV_JS_FILE_NAME = "env.js";

--- a/core/src/main/java/org/phoenixctms/ctsms/js/JSObjectMap.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/js/JSObjectMap.java
@@ -7,11 +7,12 @@ import java.util.Set;
 import jdk.nashorn.api.scripting.AbstractJSObject;
 
 //http://stackoverflow.com/questions/7519399/how-to-convert-java-map-to-a-basic-javascript-object
-public class JSObjectMap extends AbstractJSObject implements Map {
+@SuppressWarnings("restriction")
+public class JSObjectMap extends AbstractJSObject implements Map<String,Object> {
 
-	public final Map map;
+	public final Map<String,Object> map;
 
-	public JSObjectMap(Map map) {
+	public JSObjectMap(Map<String,Object> map) {
 		this.map = map;
 	}
 
@@ -37,7 +38,7 @@ public class JSObjectMap extends AbstractJSObject implements Map {
 	}
 
 	@Override
-	public Set entrySet() {
+	public Set<Entry<String,Object>> entrySet() {
 		return map.entrySet();
 	}
 
@@ -132,7 +133,7 @@ public class JSObjectMap extends AbstractJSObject implements Map {
 	}
 
 	@Override
-	public Object put(Object key, Object value) {
+	public Object put(String key, Object value) {
 		super.setMember((String) key, value);
 		return map.put(key, value);
 	}

--- a/core/src/main/java/org/phoenixctms/ctsms/js/ValidationError.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/js/ValidationError.java
@@ -3,6 +3,7 @@ package org.phoenixctms.ctsms.js;
 import jdk.nashorn.api.scripting.JSObject;
 //import sun.org.mozilla.javascript.internal.Scriptable;
 
+@SuppressWarnings("restriction")
 public class ValidationError {
 
 	private final static String ECRF_FIELD_ID = "ecrfFieldId";

--- a/pom.xml
+++ b/pom.xml
@@ -501,7 +501,7 @@
 				<configuration>
 					<source>${java.version}</source>
 					<target>${java.version}</target>
-					<showDeprecation>true</showDeprecation>
+					<showDeprecation>false</showDeprecation>
 					<showWarnings>true</showWarnings>
 					<compilerArgs>
 						<arg>-Xlint:cast,unchecked,fallthrough,finally,serial</arg>

--- a/web/src/main/java/org/phoenixctms/ctsms/web/bundle/FacesBundle.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/bundle/FacesBundle.java
@@ -16,7 +16,7 @@ public abstract class FacesBundle extends ResourceBundle {
 	protected abstract String getBundleName();
 
 	@Override
-	public Enumeration getKeys() {
+	public Enumeration<String> getKeys() {
 		return parent.getKeys();
 	}
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/BookingDurationSummaryModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/BookingDurationSummaryModel.java
@@ -19,7 +19,7 @@ import org.phoenixctms.ctsms.web.util.Settings;
 import org.phoenixctms.ctsms.web.util.Settings.Bundle;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class BookingDurationSummaryModel extends EagerDataModelBase {
+public class BookingDurationSummaryModel extends EagerDataModelBase<InventoryBookingDurationSummaryDetailVO> {
 
 	public enum BookingDurationSummaryType {
 		INVENTORY_OVERVIEW, INVENTORY, TRIAL, UNDEFINED;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/EagerDataModelBase.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/EagerDataModelBase.java
@@ -8,7 +8,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 import org.primefaces.model.SelectableDataModel;
 
-public abstract class EagerDataModelBase implements EagerDataModel, SelectableDataModel<IDVO> {
+public abstract class EagerDataModelBase<T> implements EagerDataModel, SelectableDataModel<IDVO> {
 
 	private String currentPageIdsString;
 	private List<IDVO> allRows;
@@ -34,15 +34,12 @@ public abstract class EagerDataModelBase implements EagerDataModel, SelectableDa
 		return (currentPageIdsString != null ? currentPageIdsString : "");
 	}
 
-	protected abstract Collection<?> getEagerResult(PSFVO psf);
+	protected abstract Collection<T> getEagerResult(PSFVO psf);
 
 	public boolean getHasRows() {
 		return getAllRowCount() > 0;
 	}
 
-	// public PSFVO getInitialPsf() {
-	// return null;
-	// }
 	protected Long getPageId(IDVO idvo) {
 		return idvo.getId();
 	}
@@ -57,7 +54,7 @@ public abstract class EagerDataModelBase implements EagerDataModel, SelectableDa
 		}
 	}
 
-	protected abstract <T> T getRowElement(Long id);
+	protected abstract T getRowElement(Long id);
 
 	@Override
 	public String getRowKey(IDVO element) {
@@ -65,7 +62,7 @@ public abstract class EagerDataModelBase implements EagerDataModel, SelectableDa
 	}
 
 	protected List<IDVO> load(PSFVO psf) {
-		Collection<?> eagerResult = getEagerResult(psf);
+		Collection<T> eagerResult = getEagerResult(psf);
 		IDVO.transformVoCollection(eagerResult);
 		PSFVO rowPsf;
 		if (psf != null) {
@@ -101,7 +98,7 @@ public abstract class EagerDataModelBase implements EagerDataModel, SelectableDa
 
 	@Override
 	public List<IDVO> loadAll() {
-		return load(null); // getInitialPsf());
+		return load(null); 
 	}
 
 	@Override

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/LazyDataModelBase.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/LazyDataModelBase.java
@@ -14,7 +14,7 @@ import org.primefaces.model.LazyDataModel;
 import org.primefaces.model.SelectableDataModel;
 import org.primefaces.model.SortOrder;
 
-public abstract class LazyDataModelBase extends LazyDataModel<IDVO> implements SelectableDataModel<IDVO> {
+public abstract class LazyDataModelBase<T> extends LazyDataModel<IDVO> implements SelectableDataModel<IDVO> {
 
 	private String currentPageIdsString;
 
@@ -22,7 +22,7 @@ public abstract class LazyDataModelBase extends LazyDataModel<IDVO> implements S
 		return (currentPageIdsString != null ? currentPageIdsString : "");
 	}
 
-	protected abstract Collection<?> getLazyResult(PSFVO psf);
+	protected abstract Collection<T> getLazyResult(PSFVO psf);
 
 	protected Long getPageId(IDVO idvo) {
 		return idvo.getId();
@@ -48,7 +48,7 @@ public abstract class LazyDataModelBase extends LazyDataModel<IDVO> implements S
 		}
 	}
 
-	protected abstract <T> T getRowElement(Long id);
+	protected abstract T getRowElement(Long id);
 
 	@Override
 	public String getRowKey(IDVO element) {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/SessionScopeBean.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/SessionScopeBean.java
@@ -995,7 +995,7 @@ public class SessionScopeBean {
 					MenuItem localeMenuItem = new MenuItem();
 					localeMenuItem.setValue(CommonUtil.clipString(locale.getName(), menuItemLabelClipMaxLength, CommonUtil.DEFAULT_ELLIPSIS,
 							EllipsisPlacement.TRAILING));
-					localeMenuItem.setActionListener(WebUtil.createActionListenerMethodBinding("#{sessionScopeBean.updateLocale('" + locale.getLanguage() + "')}"));
+					localeMenuItem.addActionListener(WebUtil.createActionListenerMethodBinding("#{sessionScopeBean.updateLocale('" + locale.getLanguage() + "')}"));
 					localeMenuItem.setOncomplete("handleReload(xhr, status, args)");
 					localeMenuItem.setId("localeMenuItem_" + Integer.toString(i));
 					if (CommonUtil.localeFromString(locale.getLanguage()).equals(userLocale)) {
@@ -1040,7 +1040,7 @@ public class SessionScopeBean {
 						MenuItem timeZoneMenuItem = new MenuItem();
 						timeZoneMenuItem.setValue(CommonUtil.clipString(timeZone.getName(), menuItemLabelClipMaxLength,
 								CommonUtil.DEFAULT_ELLIPSIS, EllipsisPlacement.TRAILING)); // .getDisplayName(true,TimeZone.LONG,userLocale));
-						timeZoneMenuItem.setActionListener(WebUtil.createActionListenerMethodBinding("#{sessionScopeBean.updateTimeZone('" + timeZone.getTimeZoneID()
+						timeZoneMenuItem.addActionListener(WebUtil.createActionListenerMethodBinding("#{sessionScopeBean.updateTimeZone('" + timeZone.getTimeZoneID()
 								+ "')}"));
 						timeZoneMenuItem.setOncomplete("handleReload(xhr, status, args)");
 						timeZoneMenuItem.setId("timeZoneMenuItem_" + Integer.toString(i) + "_" + Integer.toString(j));
@@ -1081,7 +1081,7 @@ public class SessionScopeBean {
 					String themeDisplayName = themeMap.get(themeName);
 					MenuItem themeMenuItem = new MenuItem();
 					themeMenuItem.setValue(CommonUtil.clipString(themeDisplayName, menuItemLabelClipMaxLength, CommonUtil.DEFAULT_ELLIPSIS, EllipsisPlacement.TRAILING));
-					themeMenuItem.setActionListener(WebUtil.createActionListenerMethodBinding("#{sessionScopeBean.updateTheme('" + themeName + "')}"));
+					themeMenuItem.addActionListener(WebUtil.createActionListenerMethodBinding("#{sessionScopeBean.updateTheme('" + themeName + "')}"));
 					themeMenuItem.setOncomplete("handleReload(xhr, status, args)");
 					themeMenuItem.setId("themeMenuItem_" + Integer.toString(i));
 					if (themeName.equals(userTheme)) {
@@ -1097,7 +1097,7 @@ public class SessionScopeBean {
 				MenuItem tooltipMenuItem = new MenuItem();
 				tooltipMenuItem.setValue(CommonUtil.clipString(showTooltips ? Messages.getString(MessageCodes.HIDE_TOOLTIPS) : Messages.getString(MessageCodes.SHOW_TOOLTIPS),
 						menuItemLabelClipMaxLength, CommonUtil.DEFAULT_ELLIPSIS, EllipsisPlacement.TRAILING));
-				tooltipMenuItem.setActionListener(WebUtil.createActionListenerMethodBinding("#{sessionScopeBean.updateShowTooltips(" + Boolean.toString(!showTooltips) + ")}"));
+				tooltipMenuItem.addActionListener(WebUtil.createActionListenerMethodBinding("#{sessionScopeBean.updateShowTooltips(" + Boolean.toString(!showTooltips) + ")}"));
 				tooltipMenuItem.setOncomplete("handleReload(xhr, status, args)");
 				tooltipMenuItem.setIcon(WebUtil.MENUBAR_ICON_STYLECLASS + " ctsms-icon-tooltip");
 				tooltipMenuItem.setId("tooltipMenuItem");
@@ -1122,7 +1122,7 @@ public class SessionScopeBean {
 			MenuItem logoutMenuItem = new MenuItem();
 			logoutMenuItem.setValue(CommonUtil.clipString(Messages.getMessage(MessageCodes.LOGOUT_LABEL, logon.getUser().getName()), menuItemLabelClipMaxLength,
 					CommonUtil.DEFAULT_ELLIPSIS, EllipsisPlacement.MID));
-			logoutMenuItem.setActionListener(WebUtil.createActionListenerMethodBinding("#{sessionScopeBean.logout()}")); // empty brackets required here...
+			logoutMenuItem.addActionListener(WebUtil.createActionListenerMethodBinding("#{sessionScopeBean.logout()}")); // empty brackets required here...
 			// logoutMenuItem.setOncomplete("handleLogout(xhr, status, args)");
 			logoutMenuItem.setIcon(WebUtil.MENUBAR_ICON_STYLECLASS + " ctsms-icon-exit");
 			logoutMenuItem.setId("logoutMenuItem");

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/ShiftDurationSummaryModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/ShiftDurationSummaryModel.java
@@ -22,7 +22,7 @@ import org.phoenixctms.ctsms.web.util.Settings;
 import org.phoenixctms.ctsms.web.util.Settings.Bundle;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class ShiftDurationSummaryModel extends EagerDataModelBase {
+public class ShiftDurationSummaryModel extends EagerDataModelBase<ShiftDurationSummaryDetailVO> {
 
 	public enum ShiftDurationSummaryType {
 		STAFF, TRIAL, STAFF_OVERVIEW, TRIAL_OVERVIEW, UNDEFINED;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/course/AdminExpiringParticipationLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/course/AdminExpiringParticipationLazyModel.java
@@ -16,7 +16,7 @@ import org.phoenixctms.ctsms.web.util.Settings;
 import org.phoenixctms.ctsms.web.util.Settings.Bundle;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class AdminExpiringParticipationLazyModel extends LazyDataModelBase {
+public class AdminExpiringParticipationLazyModel extends LazyDataModelBase<CourseParticipationStatusEntryOutVO> {
 
 	private Long reminderPeriodDays;
 	private VariablePeriod reminderPeriod;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/course/AdminUpcomingCourseLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/course/AdminUpcomingCourseLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class AdminUpcomingCourseLazyModel extends LazyDataModelBase {
+public class AdminUpcomingCourseLazyModel extends LazyDataModelBase<CourseOutVO> {
 
 	private Long departmentId;
 	private Long courseCategoryId;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/course/CourseInventoryBookingLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/course/CourseInventoryBookingLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class CourseInventoryBookingLazyModel extends LazyDataModelBase {
+public class CourseInventoryBookingLazyModel extends LazyDataModelBase<InventoryBookingOutVO> {
 
 	private Long courseId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/course/ExpiringCourseLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/course/ExpiringCourseLazyModel.java
@@ -16,7 +16,7 @@ import org.phoenixctms.ctsms.web.util.Settings;
 import org.phoenixctms.ctsms.web.util.Settings.Bundle;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class ExpiringCourseLazyModel extends LazyDataModelBase {
+public class ExpiringCourseLazyModel extends LazyDataModelBase<CourseOutVO> {
 
 	private Long departmentId;
 	private Long courseCategoryId;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/course/LecturerLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/course/LecturerLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class LecturerLazyModel extends LazyDataModelBase {
+public class LecturerLazyModel extends LazyDataModelBase<LecturerOutVO> {
 
 	private Long courseId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/inputfield/EcrfFieldUsageLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/inputfield/EcrfFieldUsageLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class EcrfFieldUsageLazyModel extends LazyDataModelBase {
+public class EcrfFieldUsageLazyModel extends LazyDataModelBase<ECRFFieldOutVO> {
 
 	private Long inputFieldId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/inputfield/InputFieldSelectionSetValueLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/inputfield/InputFieldSelectionSetValueLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class InputFieldSelectionSetValueLazyModel extends LazyDataModelBase {
+public class InputFieldSelectionSetValueLazyModel extends LazyDataModelBase<InputFieldSelectionSetValueOutVO> {
 
 	private Long inputFieldId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/inputfield/InquiryUsageLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/inputfield/InquiryUsageLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class InquiryUsageLazyModel extends LazyDataModelBase {
+public class InquiryUsageLazyModel extends LazyDataModelBase<InquiryOutVO> {
 
 	private Long inputFieldId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/inputfield/ProbandListEntryTagUsageLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/inputfield/ProbandListEntryTagUsageLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.ProbandListEntryTagOutVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class ProbandListEntryTagUsageLazyModel extends LazyDataModelBase {
+public class ProbandListEntryTagUsageLazyModel extends LazyDataModelBase<ProbandListEntryTagOutVO> {
 
 	private Long inputFieldId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/inventory/InventoryBookingLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/inventory/InventoryBookingLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class InventoryBookingLazyModel extends LazyDataModelBase {
+public class InventoryBookingLazyModel extends LazyDataModelBase<InventoryBookingOutVO> {
 
 	private Long inventoryId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/inventory/InventoryStatusEntryLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/inventory/InventoryStatusEntryLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class InventoryStatusEntryLazyModel extends LazyDataModelBase {
+public class InventoryStatusEntryLazyModel extends LazyDataModelBase<InventoryStatusEntryOutVO> {
 
 	private Long inventoryId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/inventory/InventoryStatusLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/inventory/InventoryStatusLazyModel.java
@@ -15,7 +15,7 @@ import org.phoenixctms.ctsms.web.util.Settings;
 import org.phoenixctms.ctsms.web.util.Settings.Bundle;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class InventoryStatusLazyModel extends LazyDataModelBase {
+public class InventoryStatusLazyModel extends LazyDataModelBase<InventoryStatusEntryOutVO> {
 
 	private Long inventoryId;
 	private Long departmentId;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/inventory/InventoryTagValueLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/inventory/InventoryTagValueLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class InventoryTagValueLazyModel extends LazyDataModelBase {
+public class InventoryTagValueLazyModel extends LazyDataModelBase<InventoryTagValueOutVO> {
 
 	private Long inventoryId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/inventory/MaintenanceScheduleItemLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/inventory/MaintenanceScheduleItemLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class MaintenanceScheduleItemLazyModel extends LazyDataModelBase {
+public class MaintenanceScheduleItemLazyModel extends LazyDataModelBase<MaintenanceScheduleItemOutVO> {
 
 	private Long inventoryId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/inventory/MaintenanceScheduleLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/inventory/MaintenanceScheduleLazyModel.java
@@ -16,7 +16,7 @@ import org.phoenixctms.ctsms.web.util.Settings;
 import org.phoenixctms.ctsms.web.util.Settings.Bundle;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class MaintenanceScheduleLazyModel extends LazyDataModelBase {
+public class MaintenanceScheduleLazyModel extends LazyDataModelBase<MaintenanceScheduleItemOutVO> {
 
 	private Long inventoryId;
 	private Long responsiblePersonId;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/BankAccountLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/BankAccountLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class BankAccountLazyModel extends LazyDataModelBase {
+public class BankAccountLazyModel extends LazyDataModelBase<BankAccountOutVO> {
 
 	private Long probandId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/CollidingVisitScheduleItemEagerModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/CollidingVisitScheduleItemEagerModel.java
@@ -17,7 +17,7 @@ import org.phoenixctms.ctsms.vo.VisitScheduleItemOutVO;
 import org.phoenixctms.ctsms.web.model.EagerDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class CollidingVisitScheduleItemEagerModel extends EagerDataModelBase {
+public class CollidingVisitScheduleItemEagerModel extends EagerDataModelBase<VisitScheduleItemOutVO> {
 
 	public static CollidingVisitScheduleItemEagerModel getCachedCollidingVisitScheduleItemModel(ProbandStatusEntryOutVO statusEntry, boolean allProbandGroups,
 			HashMap<Long, CollidingVisitScheduleItemEagerModel> collidingVisitScheduleItemModelCache) {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/DiagnosisLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/DiagnosisLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class DiagnosisLazyModel extends LazyDataModelBase {
+public class DiagnosisLazyModel extends LazyDataModelBase<DiagnosisOutVO> {
 
 	private Long probandId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/MedicationLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/MedicationLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class MedicationLazyModel extends LazyDataModelBase {
+public class MedicationLazyModel extends LazyDataModelBase<MedicationOutVO> {
 
 	private Long probandId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/MoneyTransferLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/MoneyTransferLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class MoneyTransferLazyModel extends LazyDataModelBase {
+public class MoneyTransferLazyModel extends LazyDataModelBase<MoneyTransferOutVO> {
 
 	private Long probandId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/ProbandAddressLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/ProbandAddressLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.ProbandAddressOutVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class ProbandAddressLazyModel extends LazyDataModelBase {
+public class ProbandAddressLazyModel extends LazyDataModelBase<ProbandAddressOutVO> {
 
 	private Long probandId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/ProbandContactDetailValueLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/ProbandContactDetailValueLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.ProbandContactDetailValueOutVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class ProbandContactDetailValueLazyModel extends LazyDataModelBase {
+public class ProbandContactDetailValueLazyModel extends LazyDataModelBase<ProbandContactDetailValueOutVO> {
 
 	private Long probandId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/ProbandInventoryBookingLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/ProbandInventoryBookingLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class ProbandInventoryBookingLazyModel extends LazyDataModelBase {
+public class ProbandInventoryBookingLazyModel extends LazyDataModelBase<InventoryBookingOutVO> {
 
 	private Long probandId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/ProbandStatusEntryLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/ProbandStatusEntryLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.ProbandStatusEntryOutVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class ProbandStatusEntryLazyModel extends LazyDataModelBase {
+public class ProbandStatusEntryLazyModel extends LazyDataModelBase<ProbandStatusEntryOutVO> {
 
 	private Long probandId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/ProbandStatusLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/ProbandStatusLazyModel.java
@@ -15,7 +15,7 @@ import org.phoenixctms.ctsms.web.util.Settings;
 import org.phoenixctms.ctsms.web.util.Settings.Bundle;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class ProbandStatusLazyModel extends LazyDataModelBase {
+public class ProbandStatusLazyModel extends LazyDataModelBase<ProbandStatusEntryOutVO> {
 
 	private Long probandId;
 	private Long departmentId;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/ProbandTagValueLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/ProbandTagValueLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.ProbandTagValueOutVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class ProbandTagValueLazyModel extends LazyDataModelBase {
+public class ProbandTagValueLazyModel extends LazyDataModelBase<ProbandTagValueOutVO> {
 
 	private Long probandId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/ProcedureLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/proband/ProcedureLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.ProcedureOutVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class ProcedureLazyModel extends LazyDataModelBase {
+public class ProcedureLazyModel extends LazyDataModelBase<ProcedureOutVO> {
 
 	private Long probandId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/CollidingCourseParticipationStatusEntryEagerModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/CollidingCourseParticipationStatusEntryEagerModel.java
@@ -13,7 +13,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.EagerDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class CollidingCourseParticipationStatusEntryEagerModel extends EagerDataModelBase {
+public class CollidingCourseParticipationStatusEntryEagerModel extends EagerDataModelBase<CourseParticipationStatusEntryOutVO> {
 
 	public static CollidingCourseParticipationStatusEntryEagerModel getCachedCollidingCourseParticipationStatusEntryModel(InventoryBookingOutVO courseBooking, boolean load,
 			HashMap<Long, CollidingCourseParticipationStatusEntryEagerModel> collidingCourseParticipationStatusEntryModelCache) {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/CollidingDutyRosterTurnEagerModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/CollidingDutyRosterTurnEagerModel.java
@@ -15,7 +15,7 @@ import org.phoenixctms.ctsms.vo.StaffStatusEntryOutVO;
 import org.phoenixctms.ctsms.web.model.EagerDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class CollidingDutyRosterTurnEagerModel extends EagerDataModelBase {
+public class CollidingDutyRosterTurnEagerModel extends EagerDataModelBase<DutyRosterTurnOutVO> {
 
 	public static CollidingDutyRosterTurnEagerModel getCachedCollidingDutyRosterTurnModel(CourseParticipationStatusEntryOutVO courseParticipation, boolean load,
 			HashMap<Long, CollidingDutyRosterTurnEagerModel> collidingDutyRosterTurnModelCache) {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/CollidingInventoryBookingEagerModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/CollidingInventoryBookingEagerModel.java
@@ -17,7 +17,7 @@ import org.phoenixctms.ctsms.vo.StaffStatusEntryOutVO;
 import org.phoenixctms.ctsms.web.model.EagerDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class CollidingInventoryBookingEagerModel extends EagerDataModelBase {
+public class CollidingInventoryBookingEagerModel extends EagerDataModelBase<InventoryBookingOutVO> {
 
 	public static CollidingInventoryBookingEagerModel getCachedCollidingInventoryBookingModel(CourseParticipationStatusEntryOutVO courseParticipation, boolean load,
 			HashMap<Long, CollidingInventoryBookingEagerModel> collidingInventoryBookingModelCache) {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/CollidingInventoryStatusEntryEagerModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/CollidingInventoryStatusEntryEagerModel.java
@@ -13,7 +13,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.EagerDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class CollidingInventoryStatusEntryEagerModel extends EagerDataModelBase {
+public class CollidingInventoryStatusEntryEagerModel extends EagerDataModelBase<InventoryStatusEntryOutVO> {
 
 	public static CollidingInventoryStatusEntryEagerModel getCachedCollidingInventoryStatusEntryModel(InventoryBookingOutVO booking, boolean load,
 			HashMap<Long, CollidingInventoryStatusEntryEagerModel> collidingInventoryStatusEntryModelCache) {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/CollidingProbandStatusEntryEagerModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/CollidingProbandStatusEntryEagerModel.java
@@ -15,7 +15,7 @@ import org.phoenixctms.ctsms.vo.VisitScheduleItemOutVO;
 import org.phoenixctms.ctsms.web.model.EagerDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class CollidingProbandStatusEntryEagerModel extends EagerDataModelBase {
+public class CollidingProbandStatusEntryEagerModel extends EagerDataModelBase<ProbandStatusEntryOutVO> {
 
 	public static CollidingProbandStatusEntryEagerModel getCachedCollidingProbandStatusEntryModel(InventoryBookingOutVO probandBooking, boolean load,
 			HashMap<Long, CollidingProbandStatusEntryEagerModel> collidingProbandStatusEntryModelCache) {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/CollidingStaffStatusEntryEagerModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/CollidingStaffStatusEntryEagerModel.java
@@ -18,7 +18,7 @@ import org.phoenixctms.ctsms.vo.VisitScheduleItemOutVO;
 import org.phoenixctms.ctsms.web.model.EagerDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class CollidingStaffStatusEntryEagerModel extends EagerDataModelBase {
+public class CollidingStaffStatusEntryEagerModel extends EagerDataModelBase<StaffStatusEntryOutVO> {
 
 	public static CollidingStaffStatusEntryEagerModel getCachedCollidingStaffStatusEntryModel(CourseParticipationStatusEntryOutVO courseParticipation, boolean load,
 			HashMap<Long, CollidingStaffStatusEntryEagerModel> collidingStaffStatusEntryModelCache) {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/CourseParticipationStatusEntryLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/CourseParticipationStatusEntryLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class CourseParticipationStatusEntryLazyModel extends LazyDataModelBase {
+public class CourseParticipationStatusEntryLazyModel extends LazyDataModelBase<CourseParticipationStatusEntryOutVO> {
 
 	private Long staffId;
 	private Long courseId;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/EcrfFieldStatusEntryLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/EcrfFieldStatusEntryLazyModel.java
@@ -12,7 +12,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class EcrfFieldStatusEntryLazyModel extends LazyDataModelBase {
+public class EcrfFieldStatusEntryLazyModel extends LazyDataModelBase<ECRFFieldStatusEntryOutVO> {
 
 	private Long listEntryId;
 	private Long ecrfFieldId;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/EcrfFieldStatusEntryLogEagerModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/EcrfFieldStatusEntryLogEagerModel.java
@@ -15,7 +15,7 @@ import org.phoenixctms.ctsms.vo.ProbandListEntryOutVO;
 import org.phoenixctms.ctsms.web.model.EagerDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class EcrfFieldStatusEntryLogEagerModel extends EagerDataModelBase {
+public class EcrfFieldStatusEntryLogEagerModel extends EagerDataModelBase<ECRFFieldStatusEntryOutVO> {
 
 	private final static PSFVO INITIAL_PSF = new PSFVO();
 	static {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/EcrfFieldValueAuditTrailLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/EcrfFieldValueAuditTrailLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class EcrfFieldValueAuditTrailLazyModel extends LazyDataModelBase {
+public class EcrfFieldValueAuditTrailLazyModel extends LazyDataModelBase<ECRFFieldValueOutVO> {
 
 	private Long listEntryId;
 	private Long ecrfFieldId;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/EcrfFieldValueAuditTrailLogEagerModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/EcrfFieldValueAuditTrailLogEagerModel.java
@@ -14,7 +14,7 @@ import org.phoenixctms.ctsms.vo.ProbandListEntryOutVO;
 import org.phoenixctms.ctsms.web.model.EagerDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class EcrfFieldValueAuditTrailLogEagerModel extends EagerDataModelBase {
+public class EcrfFieldValueAuditTrailLogEagerModel extends EagerDataModelBase<ECRFFieldValueOutVO> {
 
 	private final static PSFVO INITIAL_PSF = new PSFVO();
 	static {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/EcrfStatusEntryBeanBase.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/EcrfStatusEntryBeanBase.java
@@ -502,7 +502,7 @@ public abstract class EcrfStatusEntryBeanBase extends EcrfDataEntryBeanBase {
 		ECRFProgressVO ecrfProgress = getCachedEcrfProgress(ecrfVO, probandListEntry);
 		ECRFFieldStatusQueueCountVO result = null;
 		if (ecrfProgress != null && ecrfProgress.getStatus() != null) {
-			ArrayList<Enum> queuesToInclude = WebUtil.getEnumList(queues, ECRFFieldStatusQueue.class);
+			ArrayList<Enum<ECRFFieldStatusQueue>> queuesToInclude = WebUtil.getEnumList(queues, ECRFFieldStatusQueue.class);
 			result = new ECRFFieldStatusQueueCountVO();
 			Iterator<ECRFFieldStatusQueueCountVO> it = ecrfProgress.getEcrfFieldStatusQueueCounts().iterator();
 			while (it.hasNext()) {
@@ -727,7 +727,7 @@ public abstract class EcrfStatusEntryBeanBase extends EcrfDataEntryBeanBase {
 	public ECRFFieldStatusQueueCountVO getSectionFieldStatusCount(ECRFSectionProgressVO sectionProgress, String queues) {
 		ECRFFieldStatusQueueCountVO result = null;
 		if (sectionProgress != null) {
-			ArrayList<Enum> queuesToInclude = WebUtil.getEnumList(queues, ECRFFieldStatusQueue.class);
+			ArrayList<Enum<ECRFFieldStatusQueue>> queuesToInclude = WebUtil.getEnumList(queues, ECRFFieldStatusQueue.class);
 			result = new ECRFFieldStatusQueueCountVO();
 			Iterator<ECRFFieldStatusQueueCountVO> it = sectionProgress.getEcrfFieldStatusQueueCounts().iterator();
 			while (it.hasNext()) {
@@ -798,7 +798,7 @@ public abstract class EcrfStatusEntryBeanBase extends EcrfDataEntryBeanBase {
 		ECRFProgressSummaryVO progressSummary = getCachedEcrfProgressSummary(listEntryVO);
 		ECRFFieldStatusQueueCountVO result = null;
 		if (progressSummary != null && progressSummary.getEcrfStatusEntryCount() > 0l) {
-			ArrayList<Enum> queuesToInclude = WebUtil.getEnumList(queues, ECRFFieldStatusQueue.class);
+			ArrayList<Enum<ECRFFieldStatusQueue>> queuesToInclude = WebUtil.getEnumList(queues, ECRFFieldStatusQueue.class);
 			result = new ECRFFieldStatusQueueCountVO();
 			Iterator<ECRFFieldStatusQueueCountVO> it = progressSummary.getEcrfFieldStatusQueueCounts().iterator();
 			while (it.hasNext()) {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/HyperlinkLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/HyperlinkLazyModel.java
@@ -12,7 +12,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class HyperlinkLazyModel extends LazyDataModelBase {
+public class HyperlinkLazyModel extends LazyDataModelBase<HyperlinkOutVO> {
 
 	private Long entityId;
 	private HyperlinkModule module;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/JournalEntryLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/JournalEntryLazyModel.java
@@ -12,7 +12,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class JournalEntryLazyModel extends LazyDataModelBase {
+public class JournalEntryLazyModel extends LazyDataModelBase<JournalEntryOutVO> {
 
 	private Long entityId;
 	private JournalModule module;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/MassMailRecipientLazyModelBase.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/MassMailRecipientLazyModelBase.java
@@ -7,7 +7,7 @@ import org.phoenixctms.ctsms.vo.MassMailRecipientOutVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public abstract class MassMailRecipientLazyModelBase extends LazyDataModelBase {
+public abstract class MassMailRecipientLazyModelBase extends LazyDataModelBase<MassMailRecipientOutVO> {
 
 	protected HashMap<Long, EmailMessageVO> emailMessageCache;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/NotificationLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/NotificationLazyModel.java
@@ -15,7 +15,7 @@ import org.phoenixctms.ctsms.web.util.Settings;
 import org.phoenixctms.ctsms.web.util.Settings.Bundle;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class NotificationLazyModel extends LazyDataModelBase {
+public class NotificationLazyModel extends LazyDataModelBase<NotificationVO> {
 
 	@Override
 	protected Collection<NotificationVO> getLazyResult(PSFVO psf) {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/ProbandListEntryModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/ProbandListEntryModel.java
@@ -38,7 +38,7 @@ import org.phoenixctms.ctsms.web.util.Settings;
 import org.phoenixctms.ctsms.web.util.Settings.Bundle;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class ProbandListEntryModel extends LazyDataModelBase implements EagerDataModel {
+public class ProbandListEntryModel extends LazyDataModelBase<ProbandListEntryOutVO> implements EagerDataModel {
 
 	private static final String PROBAND_LIST_ENTRY_TAG_LABEL_WITH_FIELD_NAME = "{0}. {1}";
 	private static final String PROBAND_LIST_ENTRY_TAG_LABEL = "{0}.";

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/ProbandListStatusEntryLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/ProbandListStatusEntryLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.ProbandListStatusEntryOutVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class ProbandListStatusEntryLazyModel extends LazyDataModelBase {
+public class ProbandListStatusEntryLazyModel extends LazyDataModelBase<ProbandListStatusEntryOutVO> {
 
 	private Long probandListEntryId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/UpcomingRenewalCourseEagerModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/UpcomingRenewalCourseEagerModel.java
@@ -13,7 +13,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.EagerDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class UpcomingRenewalCourseEagerModel extends EagerDataModelBase {
+public class UpcomingRenewalCourseEagerModel extends EagerDataModelBase<CourseOutVO> {
 
 	public static UpcomingRenewalCourseEagerModel getCachedUpcomingRenewalCourseModel(CourseParticipationStatusEntryOutVO statusEntry,
 			HashMap<Long, UpcomingRenewalCourseEagerModel> upcomingRenewalCourseModelCache) {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/VisitScheduleItemLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/VisitScheduleItemLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.VisitScheduleItemOutVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class VisitScheduleItemLazyModel extends LazyDataModelBase {
+public class VisitScheduleItemLazyModel extends LazyDataModelBase<VisitScheduleItemOutVO> {
 
 	private Long trialId;
 	private Long probandId;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/CourseSearchResultLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/CourseSearchResultLazyModel.java
@@ -13,7 +13,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.util.Messages;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class CourseSearchResultLazyModel extends SearchResultLazyModel {
+public class CourseSearchResultLazyModel extends SearchResultLazyModel<CourseOutVO> {
 
 	private static final Integer GRAPH_MAX_COURSE_INSTANCES = 1;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/CriteriaLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/CriteriaLazyModel.java
@@ -12,7 +12,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class CriteriaLazyModel extends LazyDataModelBase {
+public class CriteriaLazyModel extends LazyDataModelBase<CriteriaOutVO> {
 
 	private String category;
 	private DBModule module;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/InputFieldSearchResultLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/InputFieldSearchResultLazyModel.java
@@ -13,7 +13,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.util.Messages;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class InputFieldSearchResultLazyModel extends SearchResultLazyModel {
+public class InputFieldSearchResultLazyModel extends SearchResultLazyModel<InputFieldOutVO> {
 
 	@Override
 	protected Collection<InputFieldOutVO> getLazyResultWCount(PSFVO psf) {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/InventorySearchResultLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/InventorySearchResultLazyModel.java
@@ -13,7 +13,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.util.Messages;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class InventorySearchResultLazyModel extends SearchResultLazyModel {
+public class InventorySearchResultLazyModel extends SearchResultLazyModel<InventoryOutVO> {
 
 	private static final Integer GRAPH_MAX_INVENTORY_INSTANCES = 2;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/MassMailSearchResultLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/MassMailSearchResultLazyModel.java
@@ -15,7 +15,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.util.Messages;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class MassMailSearchResultLazyModel extends SearchResultLazyModel {
+public class MassMailSearchResultLazyModel extends SearchResultLazyModel<MassMailOutVO> {
 
 	private HashMap<Long, MassMailProgressVO> massMailProgressCache;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/ProbandSearchResultLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/ProbandSearchResultLazyModel.java
@@ -13,7 +13,7 @@ import org.phoenixctms.ctsms.vo.ProbandOutVO;
 import org.phoenixctms.ctsms.web.util.Messages;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class ProbandSearchResultLazyModel extends SearchResultLazyModel {
+public class ProbandSearchResultLazyModel extends SearchResultLazyModel<ProbandOutVO> {
 
 	private static final Integer GRAPH_MAX_PROBAND_INSTANCES = 1;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/SearchResultLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/SearchResultLazyModel.java
@@ -10,7 +10,7 @@ import org.phoenixctms.ctsms.vo.CriterionInVO;
 import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 
-public abstract class SearchResultLazyModel extends LazyDataModelBase {
+public abstract class SearchResultLazyModel<T> extends LazyDataModelBase<T> {
 
 	protected CriteriaInVO criteriaIn;
 	protected HashSet<CriterionInVO> criterionsIn;
@@ -24,14 +24,14 @@ public abstract class SearchResultLazyModel extends LazyDataModelBase {
 	}
 
 	@Override
-	protected final Collection getLazyResult(PSFVO psf) {
+	protected final Collection<T> getLazyResult(PSFVO psf) {
 		if (psf != null) {
 			psf.setUpdateRowCount(false);
 		}
 		return getLazyResultWCount(psf);
 	}
 
-	protected abstract Collection getLazyResultWCount(PSFVO psf);
+	protected abstract Collection<T> getLazyResultWCount(PSFVO psf);
 
 	public void setCriteriaIn(CriteriaInVO criteria) {
 		if (criteria != null) {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/StaffSearchResultLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/StaffSearchResultLazyModel.java
@@ -13,7 +13,7 @@ import org.phoenixctms.ctsms.vo.StaffOutVO;
 import org.phoenixctms.ctsms.web.util.Messages;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class StaffSearchResultLazyModel extends SearchResultLazyModel {
+public class StaffSearchResultLazyModel extends SearchResultLazyModel<StaffOutVO> {
 
 	private static final Integer GRAPH_MAX_STAFF_INSTANCES = 2;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/TrialSearchResultLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/TrialSearchResultLazyModel.java
@@ -13,7 +13,7 @@ import org.phoenixctms.ctsms.vo.TrialOutVO;
 import org.phoenixctms.ctsms.web.util.Messages;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class TrialSearchResultLazyModel extends SearchResultLazyModel {
+public class TrialSearchResultLazyModel extends SearchResultLazyModel<TrialOutVO> {
 
 	@Override
 	protected Collection<TrialOutVO> getLazyResultWCount(PSFVO psf) {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/UserSearchResultLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/UserSearchResultLazyModel.java
@@ -13,7 +13,7 @@ import org.phoenixctms.ctsms.vo.UserOutVO;
 import org.phoenixctms.ctsms.web.util.Messages;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class UserSearchResultLazyModel extends SearchResultLazyModel {
+public class UserSearchResultLazyModel extends SearchResultLazyModel<UserOutVO> {
 
 	private static final Integer GRAPH_MAX_USER_INSTANCES = 1;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/AccountLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/AccountLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.UserOutVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class AccountLazyModel extends LazyDataModelBase {
+public class AccountLazyModel extends LazyDataModelBase<UserOutVO> {
 
 	private Long staffId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/AddresseeInventoryStatusLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/AddresseeInventoryStatusLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class AddresseeInventoryStatusLazyModel extends LazyDataModelBase {
+public class AddresseeInventoryStatusLazyModel extends LazyDataModelBase<InventoryStatusEntryOutVO> {
 
 	private Long staffId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/CompanyContactMaintenanceLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/CompanyContactMaintenanceLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class CompanyContactMaintenanceLazyModel extends LazyDataModelBase {
+public class CompanyContactMaintenanceLazyModel extends LazyDataModelBase<MaintenanceScheduleItemOutVO> {
 
 	private Long staffId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/CvPositionLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/CvPositionLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class CvPositionLazyModel extends LazyDataModelBase {
+public class CvPositionLazyModel extends LazyDataModelBase<CvPositionOutVO> {
 
 	private Long staffId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/ExpiringParticipationLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/ExpiringParticipationLazyModel.java
@@ -16,7 +16,7 @@ import org.phoenixctms.ctsms.web.util.Settings;
 import org.phoenixctms.ctsms.web.util.Settings.Bundle;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class ExpiringParticipationLazyModel extends LazyDataModelBase {
+public class ExpiringParticipationLazyModel extends LazyDataModelBase<CourseParticipationStatusEntryOutVO> {
 
 	private Long staffId;
 	private Long reminderPeriodDays;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/InstitutionCourseLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/InstitutionCourseLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class InstitutionCourseLazyModel extends LazyDataModelBase {
+public class InstitutionCourseLazyModel extends LazyDataModelBase<CourseOutVO> {
 
 	private Long staffId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/InstitutionCvPositionLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/InstitutionCvPositionLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class InstitutionCvPositionLazyModel extends LazyDataModelBase {
+public class InstitutionCvPositionLazyModel extends LazyDataModelBase<CvPositionOutVO> {
 
 	private Long staffId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/LectureLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/LectureLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class LectureLazyModel extends LazyDataModelBase {
+public class LectureLazyModel extends LazyDataModelBase<LecturerOutVO> {
 
 	private Long staffId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/OnBehalfOfInventoryBookingLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/OnBehalfOfInventoryBookingLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class OnBehalfOfInventoryBookingLazyModel extends LazyDataModelBase {
+public class OnBehalfOfInventoryBookingLazyModel extends LazyDataModelBase<InventoryBookingOutVO> {
 
 	private Long staffId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/OriginatorInventoryStatusLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/OriginatorInventoryStatusLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class OriginatorInventoryStatusLazyModel extends LazyDataModelBase {
+public class OriginatorInventoryStatusLazyModel extends LazyDataModelBase<InventoryStatusEntryOutVO> {
 
 	private Long staffId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/OwnershipInventoryLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/OwnershipInventoryLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class OwnershipInventoryLazyModel extends LazyDataModelBase {
+public class OwnershipInventoryLazyModel extends LazyDataModelBase<InventoryOutVO> {
 
 	private Long staffId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/PatientLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/PatientLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.ProbandOutVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class PatientLazyModel extends LazyDataModelBase {
+public class PatientLazyModel extends LazyDataModelBase<ProbandOutVO> {
 
 	private Long staffId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/ResponsiblePersonMaintenanceLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/ResponsiblePersonMaintenanceLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class ResponsiblePersonMaintenanceLazyModel extends LazyDataModelBase {
+public class ResponsiblePersonMaintenanceLazyModel extends LazyDataModelBase<MaintenanceScheduleItemOutVO> {
 
 	private Long staffId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/StaffAddressLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/StaffAddressLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.StaffAddressOutVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class StaffAddressLazyModel extends LazyDataModelBase {
+public class StaffAddressLazyModel extends LazyDataModelBase<StaffAddressOutVO> {
 
 	private Long staffId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/StaffContactDetailValueLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/StaffContactDetailValueLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.StaffContactDetailValueOutVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class StaffContactDetailValueLazyModel extends LazyDataModelBase {
+public class StaffContactDetailValueLazyModel extends LazyDataModelBase<StaffContactDetailValueOutVO> {
 
 	private Long staffId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/StaffDutyRosterTurnLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/StaffDutyRosterTurnLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class StaffDutyRosterTurnLazyModel extends LazyDataModelBase {
+public class StaffDutyRosterTurnLazyModel extends LazyDataModelBase<DutyRosterTurnOutVO> {
 
 	private Long staffId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/StaffStatusEntryLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/StaffStatusEntryLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.StaffStatusEntryOutVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class StaffStatusEntryLazyModel extends LazyDataModelBase {
+public class StaffStatusEntryLazyModel extends LazyDataModelBase<StaffStatusEntryOutVO> {
 
 	private Long staffId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/StaffStatusLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/StaffStatusLazyModel.java
@@ -15,7 +15,7 @@ import org.phoenixctms.ctsms.web.util.Settings;
 import org.phoenixctms.ctsms.web.util.Settings.Bundle;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class StaffStatusLazyModel extends LazyDataModelBase {
+public class StaffStatusLazyModel extends LazyDataModelBase<StaffStatusEntryOutVO> {
 
 	private Long staffId;
 	private Long departmentId;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/StaffTagValueLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/StaffTagValueLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.StaffTagValueOutVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class StaffTagValueLazyModel extends LazyDataModelBase {
+public class StaffTagValueLazyModel extends LazyDataModelBase<StaffTagValueOutVO> {
 
 	private Long staffId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/TrialMembershipLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/TrialMembershipLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.TeamMemberOutVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class TrialMembershipLazyModel extends LazyDataModelBase {
+public class TrialMembershipLazyModel extends LazyDataModelBase<TeamMemberOutVO> {
 
 	private Long staffId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/UpcomingCourseLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/staff/UpcomingCourseLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class UpcomingCourseLazyModel extends LazyDataModelBase {
+public class UpcomingCourseLazyModel extends LazyDataModelBase<CourseOutVO> {
 
 	private Long staffId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/EcrfFieldLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/EcrfFieldLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class EcrfFieldLazyModel extends LazyDataModelBase {
+public class EcrfFieldLazyModel extends LazyDataModelBase<ECRFFieldOutVO> {
 
 	private Long trialId;
 	private Long ecrfId;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/EcrfFieldStatusEntryEagerModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/EcrfFieldStatusEntryEagerModel.java
@@ -12,7 +12,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.EagerDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class EcrfFieldStatusEntryEagerModel extends EagerDataModelBase {
+public class EcrfFieldStatusEntryEagerModel extends EagerDataModelBase<ECRFFieldStatusEntryOutVO> {
 
 	private final static PSFVO INITIAL_PSF = new PSFVO();
 	static {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/EcrfFieldStatusEntryLogLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/EcrfFieldStatusEntryLogLazyModel.java
@@ -13,7 +13,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class EcrfFieldStatusEntryLogLazyModel extends LazyDataModelBase {
+public class EcrfFieldStatusEntryLogLazyModel extends LazyDataModelBase<ECRFFieldStatusEntryOutVO> {
 
 	private Long trialId;
 	private ECRFFieldStatusQueue queue;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/EcrfFieldValueAuditTrailEagerModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/EcrfFieldValueAuditTrailEagerModel.java
@@ -13,7 +13,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.EagerDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class EcrfFieldValueAuditTrailEagerModel extends EagerDataModelBase {
+public class EcrfFieldValueAuditTrailEagerModel extends EagerDataModelBase<ECRFFieldValueOutVO> {
 
 	// private Long listEntryId;
 	// private Long ecrfFieldId;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/EcrfLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/EcrfLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class EcrfLazyModel extends LazyDataModelBase {
+public class EcrfLazyModel extends LazyDataModelBase<ECRFOutVO> {
 
 	private Long trialId;
 	private Long probandGroupId;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/EcrfProgressOverviewBean.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/EcrfProgressOverviewBean.java
@@ -136,7 +136,7 @@ public class EcrfProgressOverviewBean extends ManagedBeanBase {
 		TrialECRFProgressSummaryVO trialProgressSummary = getCachedEcrfProgressSummary(trialVO);
 		ECRFFieldStatusQueueCountVO result = null;
 		if (trialProgressSummary != null && trialProgressSummary.getEcrfStatusEntryCount() > 0l) {
-			ArrayList<Enum> queuesToInclude = WebUtil.getEnumList(queues, ECRFFieldStatusQueue.class);
+			ArrayList<Enum<ECRFFieldStatusQueue>> queuesToInclude = WebUtil.getEnumList(queues, ECRFFieldStatusQueue.class);
 			result = new ECRFFieldStatusQueueCountVO();
 			Iterator<ECRFFieldStatusQueueCountVO> it = trialProgressSummary.getEcrfFieldStatusQueueCounts().iterator();
 			while (it.hasNext()) {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/EcrfProgressSummaryLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/EcrfProgressSummaryLazyModel.java
@@ -16,7 +16,7 @@ import org.phoenixctms.ctsms.web.util.Settings;
 import org.phoenixctms.ctsms.web.util.Settings.Bundle;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class EcrfProgressSummaryLazyModel extends LazyDataModelBase {
+public class EcrfProgressSummaryLazyModel extends LazyDataModelBase<TrialOutVO> {
 
 	private Long departmentId;
 	// private String costType;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/InquiryLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/InquiryLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class InquiryLazyModel extends LazyDataModelBase {
+public class InquiryLazyModel extends LazyDataModelBase<InquiryOutVO> {
 
 	private Long trialId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/ProbandGroupLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/ProbandGroupLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.ProbandGroupOutVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class ProbandGroupLazyModel extends LazyDataModelBase {
+public class ProbandGroupLazyModel extends LazyDataModelBase<ProbandGroupOutVO> {
 
 	private Long trialId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/ProbandListEntryTagLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/ProbandListEntryTagLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.ProbandListEntryTagOutVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class ProbandListEntryTagLazyModel extends LazyDataModelBase {
+public class ProbandListEntryTagLazyModel extends LazyDataModelBase<ProbandListEntryTagOutVO> {
 
 	private Long trialId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/ProbandMoneyTransferNoParticipationSummaryLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/ProbandMoneyTransferNoParticipationSummaryLazyModel.java
@@ -10,7 +10,7 @@ import org.phoenixctms.ctsms.vo.MoneyTransferSummaryVO;
 import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class ProbandMoneyTransferNoParticipationSummaryLazyModel extends ProbandMoneyTransferSummaryLazyModelBase {
+public class ProbandMoneyTransferNoParticipationSummaryLazyModel extends ProbandMoneyTransferSummaryLazyModelBase<MoneyTransferSummaryVO> {
 
 	private boolean total;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/ProbandMoneyTransferSummaryLazyModelBase.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/ProbandMoneyTransferSummaryLazyModelBase.java
@@ -12,7 +12,7 @@ import org.phoenixctms.ctsms.web.util.SettingCodes;
 import org.phoenixctms.ctsms.web.util.Settings;
 import org.phoenixctms.ctsms.web.util.Settings.Bundle;
 
-public abstract class ProbandMoneyTransferSummaryLazyModelBase extends LazyDataModelBase {
+public abstract class ProbandMoneyTransferSummaryLazyModelBase<T> extends LazyDataModelBase<T> {
 
 	protected Long trialId;
 	private Collection<String> costTypesTruncated;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/RandomizationListLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/RandomizationListLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.StratificationRandomizationListOutVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class RandomizationListLazyModel extends LazyDataModelBase {
+public class RandomizationListLazyModel extends LazyDataModelBase<StratificationRandomizationListOutVO> {
 
 	private Long trialId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/TeamMemberLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/TeamMemberLazyModel.java
@@ -12,7 +12,7 @@ import org.phoenixctms.ctsms.web.model.IDVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class TeamMemberLazyModel extends LazyDataModelBase {
+public class TeamMemberLazyModel extends LazyDataModelBase<TeamMemberOutVO> {
 
 	private Long trialId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/TimelineEventLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/TimelineEventLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.TimelineEventOutVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class TimelineEventLazyModel extends LazyDataModelBase {
+public class TimelineEventLazyModel extends LazyDataModelBase<TimelineEventOutVO> {
 
 	private Long trialId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/TimelineScheduleLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/TimelineScheduleLazyModel.java
@@ -16,7 +16,7 @@ import org.phoenixctms.ctsms.web.util.Settings;
 import org.phoenixctms.ctsms.web.util.Settings.Bundle;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class TimelineScheduleLazyModel extends LazyDataModelBase {
+public class TimelineScheduleLazyModel extends LazyDataModelBase<TimelineEventOutVO> {
 
 	private Long trialId;
 	private Long departmentId;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/TrialCourseLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/TrialCourseLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class TrialCourseLazyModel extends LazyDataModelBase {
+public class TrialCourseLazyModel extends LazyDataModelBase<CourseOutVO> {
 
 	private Long trialId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/TrialDutyRosterTurnLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/TrialDutyRosterTurnLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class TrialDutyRosterTurnLazyModel extends LazyDataModelBase {
+public class TrialDutyRosterTurnLazyModel extends LazyDataModelBase<DutyRosterTurnOutVO> {
 
 	private Long trialId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/TrialInventoryBookingLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/TrialInventoryBookingLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class TrialInventoryBookingLazyModel extends LazyDataModelBase {
+public class TrialInventoryBookingLazyModel extends LazyDataModelBase<InventoryBookingOutVO> {
 
 	private Long trialId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/TrialMassMailLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/TrialMassMailLazyModel.java
@@ -13,7 +13,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class TrialMassMailLazyModel extends LazyDataModelBase {
+public class TrialMassMailLazyModel extends LazyDataModelBase<MassMailOutVO> {
 
 	private HashMap<Long, MassMailProgressVO> massMailProgressCache;
 	private Long trialId;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/TrialMoneyTransferSummaryLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/TrialMoneyTransferSummaryLazyModel.java
@@ -16,7 +16,7 @@ import org.phoenixctms.ctsms.web.util.Settings;
 import org.phoenixctms.ctsms.web.util.Settings.Bundle;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class TrialMoneyTransferSummaryLazyModel extends LazyDataModelBase {
+public class TrialMoneyTransferSummaryLazyModel extends LazyDataModelBase<MoneyTransferSummaryVO> {
 
 	private Long departmentId;
 	private Long probandDepartmentId;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/TrialTagValueLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/TrialTagValueLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.TrialTagValueOutVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class TrialTagValueLazyModel extends LazyDataModelBase {
+public class TrialTagValueLazyModel extends LazyDataModelBase<TrialTagValueOutVO> {
 
 	private Long trialId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/VisitLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/VisitLazyModel.java
@@ -11,7 +11,7 @@ import org.phoenixctms.ctsms.vo.VisitOutVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class VisitLazyModel extends LazyDataModelBase {
+public class VisitLazyModel extends LazyDataModelBase<VisitOutVO> {
 
 	private Long trialId;
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/user/UserActivityLazyModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/user/UserActivityLazyModel.java
@@ -13,7 +13,7 @@ import org.phoenixctms.ctsms.vo.PSFVO;
 import org.phoenixctms.ctsms.web.model.LazyDataModelBase;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 
-public class UserActivityLazyModel extends LazyDataModelBase {
+public class UserActivityLazyModel extends LazyDataModelBase<JournalEntryOutVO> {
 
 	private Long modifiedUserId;
 	private JournalModule module;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/util/WebUtil.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/util/WebUtil.java
@@ -2153,11 +2153,11 @@ public final class WebUtil {
 		return null;
 	}
 
-	public static ArrayList<Enum> getEnumList(String value, Class enumeration) {
-		ArrayList<Enum> result;
+	public static <T extends Enum<T>> ArrayList<Enum<T>> getEnumList(String value, Class<T> enumeration) {
+		ArrayList<Enum<T>> result;
 		if (value != null && value.length() > 0) {
 			String[] list = EL_ENUM_LIST_REGEXP.split(value, -1);
-			result = new ArrayList<Enum>(list.length);
+			result = new ArrayList<Enum<T>>(list.length);
 			for (int i = 0; i < list.length; i++) {
 				String name = list[i].trim();
 				if (name.length() > 0) {
@@ -2165,7 +2165,7 @@ public final class WebUtil {
 				}
 			}
 		} else {
-			result = new ArrayList<Enum>();
+			result = new ArrayList<Enum<T>>();
 		}
 		return result;
 	}

--- a/web/src/main/java/org/phoenixctms/ctsms/web/util/WebUtil.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/util/WebUtil.java
@@ -20,10 +20,10 @@ import javax.faces.FacesException;
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
-import javax.faces.el.MethodBinding;
 import javax.faces.event.ActionEvent;
 import javax.faces.event.ExceptionQueuedEvent;
 import javax.faces.event.ExceptionQueuedEventContext;
+import javax.faces.event.MethodExpressionActionListener;
 import javax.faces.model.SelectItem;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
@@ -435,10 +435,11 @@ public final class WebUtil {
 			return getNoCoursePickedMessage();
 		}
 	}
-
-	public static MethodBinding createActionListenerMethodBinding(String actionListenerString) {
-		return FacesContext.getCurrentInstance().getApplication()
-				.createMethodBinding(actionListenerString, new Class[] { ActionEvent.class });
+	
+	public static MethodExpressionActionListener createActionListenerMethodBinding(String actionListenerExpression) {
+	    FacesContext context = FacesContext.getCurrentInstance();
+	    return new MethodExpressionActionListener(context.getApplication().getExpressionFactory()
+	        .createMethodExpression(context.getELContext(), actionListenerExpression, null, new Class[] {ActionEvent.class}));
 	}
 
 	public static Converter createConverter(String converterId) {


### PR DESCRIPTION
- couple of fixes for proper use of generics
- replace deprecated usage of `MethodBinding` (replacement of `set..`->`add..` shouldn't be an issue, as it is only initialized once)