### PR TITLE
External dataprovider

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Eclipse IDE
 The following was tested on a vanilla Windows 10 VM.
 
 1. Prerequisites:
-* download and install a recent JDK (eg. Oracle JDK1.8.0 u201 64bit)
+* download and install a recent Java8 JDK (eg. Oracle JDK1.8.0 u201 64bit)
 * download and install git
 * download a recent Apache Maven (eg. apache-maven-3.6.0-bin.zip, extract to C:\apache-maven-3.6.0)
 

--- a/core/db/schema-up-170.sql
+++ b/core/db/schema-up-170.sql
@@ -1,0 +1,2 @@
+
+insert into PROBAND_LIST_STATUS_TRANSITION values ((select ID from PROBAND_LIST_STATUS_TYPE where NAME_L10N_KEY='candidate'), (select ID from PROBAND_LIST_STATUS_TYPE where NAME_L10N_KEY='ongoing'));

--- a/core/src/exec/java/org/phoenixctms/ctsms/executable/DBTool.java
+++ b/core/src/exec/java/org/phoenixctms/ctsms/executable/DBTool.java
@@ -27,8 +27,11 @@ import org.phoenixctms.ctsms.executable.migration.ProbandListStatusEntryReasonDe
 import org.phoenixctms.ctsms.executable.xls.XlsExporter;
 import org.phoenixctms.ctsms.executable.xls.XlsImporter;
 import org.phoenixctms.ctsms.util.CommonUtil;
+import org.phoenixctms.ctsms.util.Compile;
 import org.phoenixctms.ctsms.util.CoreUtil;
 import org.phoenixctms.ctsms.util.DBToolOptions;
+import org.phoenixctms.ctsms.util.ExecDefaultSettings;
+import org.phoenixctms.ctsms.util.ExecSettingCodes;
 import org.phoenixctms.ctsms.util.ExecSettings;
 import org.phoenixctms.ctsms.util.ExecUtil;
 import org.phoenixctms.ctsms.util.JobOutput;
@@ -1306,9 +1309,16 @@ public class DBTool {
 		return probandListStatusEntryReasonDecryptInitializer;
 	}
 
-	private ProductionDataProvider getProductionDataProvider() {
+	private ProductionDataProvider getProductionDataProvider() throws InstantiationException, IllegalAccessException, ClassNotFoundException {
 		if (productionDataProvider == null) {
-			productionDataProvider = context.getBean(ProductionDataProvider.class);
+			String className = ExecSettings.getString(ExecSettingCodes.DATA_PROVIDER_CLASS, ExecDefaultSettings.DATA_PROVIDER_CLASS);
+			if (CommonUtil.isEmptyString(className)) {
+				productionDataProvider = context.getBean(ProductionDataProvider.class);
+			} else {
+				productionDataProvider = (ProductionDataProvider) Compile
+						.loadClass(className, ExecSettings.getStringList(ExecSettingCodes.DATA_PROVIDER_CLASS_SOURCE_FILES, ExecDefaultSettings.DATA_PROVIDER_CLASS_SOURCE_FILES))
+						.newInstance();
+			}
 			productionDataProvider.setJobOutput(getJobOutput());
 		}
 		return productionDataProvider;

--- a/core/src/exec/java/org/phoenixctms/ctsms/executable/ProductionDataProvider.java
+++ b/core/src/exec/java/org/phoenixctms/ctsms/executable/ProductionDataProvider.java
@@ -2277,7 +2277,7 @@ public class ProductionDataProvider {
 				true,
 				getProbandListStatusLogLevels());
 		updateProbandListStatusType(candidateProbandListStatusType,
-				getProbandListStatusTransitions(candidateProbandListStatusType, contactedProbandListStatusType, cancelledProbandListStatusType));
+				getProbandListStatusTransitions(candidateProbandListStatusType, contactedProbandListStatusType, cancelledProbandListStatusType, ongoingProbandListStatusType));
 		updateProbandListStatusType(signupProbandListStatusType,
 				getProbandListStatusTransitions(signupProbandListStatusType, contactedProbandListStatusType, cancelledProbandListStatusType));
 		updateProbandListStatusType(contactedProbandListStatusType,
@@ -2822,7 +2822,6 @@ public class ProductionDataProvider {
 				false,
 				false,
 				false);
-		
 		createJobType(
 				JobModule.TRIAL_JOB,
 				"export_ecrfs",
@@ -3278,7 +3277,6 @@ public class ProductionDataProvider {
 				true,
 				false,
 				false);
-		
 		createJobType(
 				JobModule.TRIAL_JOB,
 				"import_randomization_list_codes",
@@ -3291,8 +3289,7 @@ public class ProductionDataProvider {
 				true,
 				false,
 				false,
-				false);		
-		
+				false);
 		jobOutput.println("job types created");
 	}
 

--- a/core/src/exec/java/org/phoenixctms/ctsms/util/ExecDefaultSettings.java
+++ b/core/src/exec/java/org/phoenixctms/ctsms/util/ExecDefaultSettings.java
@@ -1,5 +1,7 @@
 package org.phoenixctms.ctsms.util;
 
+import java.util.ArrayList;
+
 public class ExecDefaultSettings {
 
 	public final static String DEFAULT_ENCODING = "UTF-8";
@@ -7,6 +9,8 @@ public class ExecDefaultSettings {
 	public final static String DATE_PATTERN = "yyyy-MM-dd";
 	public final static String TIME_PATTERN = "HH:mm:ss";
 	public static final String DBTOOL_LOCK_FILE_NAME = null;
+	public static final String DATA_PROVIDER_CLASS = null;
+	public static final ArrayList<String> DATA_PROVIDER_CLASS_SOURCE_FILES = null;
 
 	private ExecDefaultSettings() {
 	}

--- a/core/src/exec/java/org/phoenixctms/ctsms/util/ExecSettingCodes.java
+++ b/core/src/exec/java/org/phoenixctms/ctsms/util/ExecSettingCodes.java
@@ -7,4 +7,6 @@ public interface ExecSettingCodes {
 	public final static String DATE_PATTERN = "date_pattern";
 	public final static String TIME_PATTERN = "time_pattern";
 	public static final String DBTOOL_LOCK_FILE_NAME = "dbtool_lock_file_name";
+	public static final String DATA_PROVIDER_CLASS = "data_provider_class";
+	public static final String DATA_PROVIDER_CLASS_SOURCE_FILES = "data_provider_class_source_files";
 }

--- a/core/src/exec/java/org/phoenixctms/ctsms/util/ExecSettings.java
+++ b/core/src/exec/java/org/phoenixctms/ctsms/util/ExecSettings.java
@@ -1,5 +1,6 @@
 package org.phoenixctms.ctsms.util;
 
+import java.util.ArrayList;
 import java.util.Locale;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
@@ -59,6 +60,10 @@ public final class ExecSettings {
 
 	public static String getString(String key, String defaultValue) {
 		return CommonUtil.getValue(key, getBundle(false), defaultValue);
+	}
+
+	public static ArrayList<String> getStringList(String key, ArrayList<String> defaultValue) {
+		return CommonUtil.getValueStringList(key, getBundle(false), defaultValue);
 	}
 
 	public static void setBundleBasename(String basename) { // synchronized

--- a/core/src/exec/resources/ctsms-dbtool.properties
+++ b/core/src/exec/resources/ctsms-dbtool.properties
@@ -7,3 +7,6 @@ time_pattern=HH:mm:ss
 
 dbtool_lock_file_name=/ctsms/{0}.lock
 #dbtool_lock_file_name=C\:\\ctsms\\{0}.lock
+
+#data_provider_class=
+#data_provider_source_files=


### PR DESCRIPTION
apply the mechanism to use external class overloads introduced with https://github.com/phoenixctms/ctsms/pull/96 to override ProductionDataProvider.java.

This allows to use `dbtoo.sh -i` to initialize the db for custom builds, using a own ProductionDataProvider.java.