### PR TITLE
add font selector for p:editor controls

### DIFF
--- a/web/src/main/webapp/META-INF/includes/massmail/massMailMain.xhtml
+++ b/web/src/main/webapp/META-INF/includes/massmail/massMailMain.xhtml
@@ -541,7 +541,7 @@
 									<h:panelGroup>
 										<p:editor id="texttemplate"
 											value="#{massMailBean.in.textTemplate}" required="true"
-											controls="bold italic underline strikethrough color indent outdent bullets numbering image link unlink source"
+											controls="font bold italic underline strikethrough color indent outdent bullets numbering image link unlink source"
 											height="280" styleClass="ctsms-editor"
 											label="#{massmaillabels.mass_mail_texttemplate}">
 										</p:editor>

--- a/web/src/main/webapp/META-INF/includes/trial/trialMain.xhtml
+++ b/web/src/main/webapp/META-INF/includes/trial/trialMain.xhtml
@@ -647,7 +647,7 @@
 									<h:panelGroup>
 										<p:editor id="trialsignupdescription"
 											value="#{trialBean.in.signupDescription}" required="false"
-											controls="bold italic underline strikethrough color indent outdent bullets numbering image link unlink source"
+											controls="font bold italic underline strikethrough color indent outdent bullets numbering image link unlink source"
 											height="280" styleClass="ctsms-editor"
 											label="#{triallabels.trial_signup_description}">
 										</p:editor>


### PR DESCRIPTION
p:editor controls allow to create&format html-based content, eg. for trialdescriptions in the SelfSignup-Portal, or email body of massmails.

While there were control for font style (bold, italic, ..), there (intentioinally) was no option to change the font type so far.

However there can be situations where working in the editor causes paragraphs to loose the default font spec.

```
..
<span style="font-size:10.0pt;font-family:&quot;Arial&quot;,sans-serif">Messung der Anti-Spike-Protein- und der neutralisierenden Antikörper (soll untersuchen, wie gut die Impfung gewirkt hat und nach einem Jahr noch wirkt)<o:p></o:p></span></li></ul>
<div>
<p class="MsoNormal"><span style="font-size:10.0pt">Die Impfung selbst ist nicht Teil d
..
```

We therefore introduce a button to control the font type, for an option to fix such situations in case.

![grafik](https://user-images.githubusercontent.com/17864099/114033434-8daa1500-987d-11eb-8e0a-eee7a038b51a.png)
