### PR TITLE
user timezones in PDF documents WIP

### DIFF
--- a/core/src/main/java/org/phoenixctms/ctsms/domain/CourseParticipationStatusEntryDaoImpl.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/domain/CourseParticipationStatusEntryDaoImpl.java
@@ -534,8 +534,9 @@ public class CourseParticipationStatusEntryDaoImpl
 					Locales.CV_PDF,
 					CVPDFLabelCodes.POSITION_COURSE_DATE,
 					CVPDFDefaultSettings.POSITION_COURSE_DATE_LABEL,
-					Settings.getSimpleDateFormat(CVPDFSettingCodes.POSITION_DATE_PATTERN, Bundle.CV_PDF, CVPDFDefaultSettings.POSITION_DATE_PATTERN, Locales.CV_PDF).format(
-							course.getStop())));
+					Settings.getSimpleDateFormat(CVPDFSettingCodes.POSITION_DATE_PATTERN, Bundle.CV_PDF, CVPDFDefaultSettings.POSITION_DATE_PATTERN, Locales.CV_PDF,
+							Settings.getBoolean(CVPDFSettingCodes.DATE_USER_TIME_ZONE, Bundle.SETTINGS, CVPDFDefaultSettings.DATE_USER_TIME_ZONE)).format(
+									course.getStop())));
 			target.setLabel1(sb.toString());
 			Staff institution = course.getInstitution();
 			if (institution != null) {

--- a/core/src/main/java/org/phoenixctms/ctsms/domain/CvPositionDaoImpl.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/domain/CvPositionDaoImpl.java
@@ -345,7 +345,7 @@ public class CvPositionDaoImpl
 		Date start = source.getStart();
 		Date stop = source.getStop();
 		DateFormat cvPositionDateFormat = Settings.getSimpleDateFormat(CVPDFSettingCodes.POSITION_DATE_PATTERN, Bundle.CV_PDF, CVPDFDefaultSettings.POSITION_DATE_PATTERN,
-				Locales.CV_PDF);
+				Locales.CV_PDF, Settings.getBoolean(CVPDFSettingCodes.DATE_USER_TIME_ZONE, Bundle.SETTINGS, CVPDFDefaultSettings.DATE_USER_TIME_ZONE));
 		if (start != null && stop != null) {
 			sb.append(L10nUtil.getCVPDFLabel(Locales.CV_PDF, CVPDFLabelCodes.POSITION_FROM_TO, CVPDFDefaultSettings.POSITION_FROM_TO_LABEL, cvPositionDateFormat.format(start),
 					cvPositionDateFormat.format(stop)));

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/CVPDFBlock.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/CVPDFBlock.java
@@ -78,7 +78,8 @@ public class CVPDFBlock {
 
 	protected String getDateOfBirth() {
 		if (staff != null && staff.isPerson() && staff.getDateOfBirth() != null) {
-			return Settings.getSimpleDateFormat(CVPDFSettingCodes.DATE_OF_BIRTH_DATE_PATTERN, Bundle.CV_PDF, CVPDFDefaultSettings.DATE_OF_BIRTH_DATE_PATTERN, Locales.CV_PDF)
+			return Settings
+					.getSimpleDateFormat(CVPDFSettingCodes.DATE_OF_BIRTH_DATE_PATTERN, Bundle.CV_PDF, CVPDFDefaultSettings.DATE_OF_BIRTH_DATE_PATTERN, Locales.CV_PDF) //no usertimezone
 					.format(staff.getDateOfBirth());
 		}
 		return "";
@@ -117,7 +118,9 @@ public class CVPDFBlock {
 	protected String getSignatureLabel() {
 		if (staff != null && staff.isPerson()) {
 			return L10nUtil.getCVPDFLabel(Locales.CV_PDF, CVPDFLabelCodes.SIGNATURE_ANNOTATION, PDFUtil.DEFAULT_LABEL, CommonUtil.getCvStaffName(staff), now == null ? null
-					: Settings.getSimpleDateFormat(CVPDFSettingCodes.SIGNATURE_DATE_PATTERN, Bundle.CV_PDF, CVPDFDefaultSettings.SIGNATURE_DATE_PATTERN, Locales.CV_PDF)
+					: Settings
+							.getSimpleDateFormat(CVPDFSettingCodes.SIGNATURE_DATE_PATTERN, Bundle.CV_PDF, CVPDFDefaultSettings.SIGNATURE_DATE_PATTERN, Locales.CV_PDF,
+									Settings.getBoolean(CVPDFSettingCodes.DATE_USER_TIME_ZONE, Bundle.SETTINGS, CVPDFDefaultSettings.DATE_USER_TIME_ZONE))
 							.format(now));
 		}
 		return "";

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/CVPDFDefaultSettings.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/CVPDFDefaultSettings.java
@@ -52,6 +52,7 @@ public final class CVPDFDefaultSettings {
 	public static final boolean PASSED_COURSES_ONLY = true;
 	public static final String PAINTER_CLASS = null;
 	public static final ArrayList<String> PAINTER_SOURCE_FILES = null;
+	public static final boolean DATE_USER_TIME_ZONE = true;
 
 	private CVPDFDefaultSettings() {
 	}

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/CVPDFSettingCodes.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/CVPDFSettingCodes.java
@@ -49,4 +49,5 @@ public interface CVPDFSettingCodes {
 	public static final String PAINTER_CLASS = "painter_class";
 	public static final String PAINTER_SOURCE_FILES = "painter_source_files";
 	public static final String PASSED_COURSES_ONLY = "passed_courses_only";
+	public static final String DATE_USER_TIME_ZONE = "date_user_time_zone";
 }

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/CourseCertificatePDFBlock.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/CourseCertificatePDFBlock.java
@@ -156,8 +156,9 @@ public class CourseCertificatePDFBlock {
 		if (course != null) {
 			Date start = course.getStart();
 			Date stop = course.getStop();
-			DateFormat coursePeriodDateFormat = Settings.getSimpleDateFormat(CourseCertificatePDFSettingCodes.COURSE_DATE_TIME_PATTERN, Bundle.COURSE_CERTIFICATE_PDF,
-					CourseCertificatePDFDefaultSettings.COURSE_DATE_TIME_PATTERN, Locales.COURSE_CERTIFICATE_PDF);
+			DateFormat coursePeriodDateFormat = Settings.getSimpleDateFormat(CourseCertificatePDFSettingCodes.COURSE_DATE_PATTERN, Bundle.COURSE_CERTIFICATE_PDF,
+					CourseCertificatePDFDefaultSettings.COURSE_DATE_PATTERN, Locales.COURSE_CERTIFICATE_PDF,
+					Settings.getBoolean(CourseCertificatePDFSettingCodes.DATE_USER_TIME_ZONE, Bundle.SETTINGS, CourseCertificatePDFDefaultSettings.DATE_USER_TIME_ZONE));
 			if (start != null && stop != null) {
 				return L10nUtil.getCourseCertificatePDFLabel(Locales.COURSE_CERTIFICATE_PDF, CourseCertificatePDFLabelCodes.COURSE_FROM_TO, PDFUtil.DEFAULT_LABEL,
 						coursePeriodDateFormat.format(start), coursePeriodDateFormat.format(stop));
@@ -173,8 +174,9 @@ public class CourseCertificatePDFBlock {
 	protected String getCourseValidityString() {
 		if (course != null && course.getValidityPeriod() != null) {
 			String courseValidityString;
-			DateFormat coursePeriodDateFormat = Settings.getSimpleDateFormat(CourseCertificatePDFSettingCodes.COURSE_DATE_TIME_PATTERN, Bundle.COURSE_CERTIFICATE_PDF,
-					CourseCertificatePDFDefaultSettings.COURSE_DATE_TIME_PATTERN, Locales.COURSE_CERTIFICATE_PDF);
+			DateFormat coursePeriodDateFormat = Settings.getSimpleDateFormat(CourseCertificatePDFSettingCodes.COURSE_DATE_PATTERN, Bundle.COURSE_CERTIFICATE_PDF,
+					CourseCertificatePDFDefaultSettings.COURSE_DATE_PATTERN, Locales.COURSE_CERTIFICATE_PDF,
+					Settings.getBoolean(CourseCertificatePDFSettingCodes.DATE_USER_TIME_ZONE, Bundle.SETTINGS, CourseCertificatePDFDefaultSettings.DATE_USER_TIME_ZONE));
 			if (!VariablePeriod.EXPLICIT.equals(course.getValidityPeriod().getPeriod())) {
 				courseValidityString = L10nUtil.getVariablePeriodName(Locales.COURSE_CERTIFICATE_PDF, course.getValidityPeriod().getPeriod().name());
 			} else {

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/CourseCertificatePDFDefaultSettings.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/CourseCertificatePDFDefaultSettings.java
@@ -6,7 +6,7 @@ import org.phoenixctms.ctsms.enumeration.Color;
 
 public final class CourseCertificatePDFDefaultSettings {
 
-	public static final String COURSE_DATE_TIME_PATTERN = "d. MMMM yyyy";
+	public static final String COURSE_DATE_PATTERN = "d. MMMM yyyy";
 	public final static boolean LANDSCAPE = false;
 	public final static float X_COLUMN_INDENT = 200.0f;
 	public final static float X_FRAME_INDENT = 2.5f;

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/CourseCertificatePDFDefaultSettings.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/CourseCertificatePDFDefaultSettings.java
@@ -26,6 +26,7 @@ public final class CourseCertificatePDFDefaultSettings {
 	public static final boolean SHOW_PAGE_NUMBERS = true;
 	public static final String PAINTER_CLASS = null;
 	public static final ArrayList<String> PAINTER_SOURCE_FILES = null;
+	public static final boolean DATE_USER_TIME_ZONE = true;
 
 	private CourseCertificatePDFDefaultSettings() {
 	}

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/CourseCertificatePDFSettingCodes.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/CourseCertificatePDFSettingCodes.java
@@ -26,4 +26,5 @@ public interface CourseCertificatePDFSettingCodes {
 	public static final String SHOW_PAGE_NUMBERS = "show_page_numbers";
 	public static final String PAINTER_CLASS = "painter_class";
 	public static final String PAINTER_SOURCE_FILES = "painter_source_files";
+	public static final String DATE_USER_TIME_ZONE = "date_user_time_zone";
 }

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/CourseCertificatePDFSettingCodes.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/CourseCertificatePDFSettingCodes.java
@@ -2,7 +2,7 @@ package org.phoenixctms.ctsms.pdf;
 
 public interface CourseCertificatePDFSettingCodes {
 
-	public final static String COURSE_DATE_TIME_PATTERN = "course_date_time_pattern";
+	public final static String COURSE_DATE_PATTERN = "course_date_pattern";
 	public final static String TEMPLATE_FILE_NAME = "template_file_name";
 	public final static String FONT_A = "font_a";
 	public final static String FONT_B = "font_b";

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/CourseParticipantListPDFBlock.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/CourseParticipantListPDFBlock.java
@@ -98,7 +98,9 @@ public class CourseParticipantListPDFBlock {
 	protected String getBookingString(InventoryBookingOutVO booking) {
 		if (booking != null) {
 			DateFormat bookingDateFormat = Settings.getSimpleDateFormat(CourseParticipantListPDFSettingCodes.BOOKING_DATE_TIME_PATTERN, Bundle.COURSE_PARTICIPANT_LIST_PDF,
-					CourseParticipantListPDFDefaultSettings.BOOKING_DATE_TIME_PATTERN, Locales.COURSE_PARTICIPANT_LIST_PDF);
+					CourseParticipantListPDFDefaultSettings.BOOKING_DATE_TIME_PATTERN, Locales.COURSE_PARTICIPANT_LIST_PDF,
+					Settings.getBoolean(CourseParticipantListPDFSettingCodes.DATE_TIME_USER_TIME_ZONE, Bundle.SETTINGS,
+							CourseParticipantListPDFDefaultSettings.DATE_TIME_USER_TIME_ZONE));
 			return L10nUtil.getCourseParticipantListPDFLabel(Locales.COURSE_PARTICIPANT_LIST_PDF, CourseParticipantListPDFLabelCodes.BOOKING_FROM_TO, PDFUtil.DEFAULT_LABEL,
 					booking.getInventory().getName(), bookingDateFormat.format(booking.getStart()), bookingDateFormat.format(booking.getStop()));
 		}
@@ -148,8 +150,9 @@ public class CourseParticipantListPDFBlock {
 		if (course != null) {
 			Date start = course.getStart();
 			Date stop = course.getStop();
-			DateFormat coursePeriodDateFormat = Settings.getSimpleDateFormat(CourseParticipantListPDFSettingCodes.COURSE_DATE_TIME_PATTERN, Bundle.COURSE_PARTICIPANT_LIST_PDF,
-					CourseParticipantListPDFDefaultSettings.COURSE_DATE_TIME_PATTERN, Locales.COURSE_PARTICIPANT_LIST_PDF);
+			DateFormat coursePeriodDateFormat = Settings.getSimpleDateFormat(CourseParticipantListPDFSettingCodes.COURSE_DATE_PATTERN, Bundle.COURSE_PARTICIPANT_LIST_PDF,
+					CourseParticipantListPDFDefaultSettings.COURSE_DATE_PATTERN, Locales.COURSE_PARTICIPANT_LIST_PDF,
+					Settings.getBoolean(CourseParticipantListPDFSettingCodes.DATE_USER_TIME_ZONE, Bundle.SETTINGS, CourseParticipantListPDFDefaultSettings.DATE_USER_TIME_ZONE));
 			if (start != null && stop != null) {
 				return L10nUtil.getCourseParticipantListPDFLabel(Locales.COURSE_PARTICIPANT_LIST_PDF, CourseParticipantListPDFLabelCodes.COURSE_FROM_TO, PDFUtil.DEFAULT_LABEL,
 						coursePeriodDateFormat.format(start), coursePeriodDateFormat.format(stop));
@@ -271,8 +274,11 @@ public class CourseParticipantListPDFBlock {
 						CourseParticipantListPDFLabelCodes.HEADLINE_LINE2,
 						PDFUtil.DEFAULT_LABEL,
 						now == null ? null
-								: Settings.getSimpleDateFormat(CourseParticipantListPDFSettingCodes.NOW_DATE_TIME_PATTERN, Bundle.COURSE_PARTICIPANT_LIST_PDF,
-										CourseParticipantListPDFDefaultSettings.NOW_DATE_TIME_PATTERN, Locales.COURSE_PARTICIPANT_LIST_PDF).format(now));
+								: Settings.getSimpleDateFormat(CourseParticipantListPDFSettingCodes.NOW_DATE_PATTERN, Bundle.COURSE_PARTICIPANT_LIST_PDF,
+										CourseParticipantListPDFDefaultSettings.NOW_DATE_PATTERN, Locales.COURSE_PARTICIPANT_LIST_PDF, Settings.getBoolean(
+												CourseParticipantListPDFSettingCodes.DATE_USER_TIME_ZONE, Bundle.SETTINGS,
+												CourseParticipantListPDFDefaultSettings.DATE_USER_TIME_ZONE))
+										.format(now));
 				x = cursor.getBlockCenterX();
 				y = cursor.getBlockY();
 				if (!CommonUtil.isEmptyString(line1)) {
@@ -313,8 +319,11 @@ public class CourseParticipantListPDFBlock {
 							Settings.getColor(CourseParticipantListPDFSettingCodes.TEXT_COLOR, Bundle.COURSE_PARTICIPANT_LIST_PDF,
 									CourseParticipantListPDFDefaultSettings.TEXT_COLOR),
 							now == null ? ""
-									: Settings.getSimpleDateFormat(CourseParticipantListPDFSettingCodes.NOW_DATE_TIME_PATTERN, Bundle.COURSE_PARTICIPANT_LIST_PDF,
-											CourseParticipantListPDFDefaultSettings.NOW_DATE_TIME_PATTERN, Locales.COURSE_PARTICIPANT_LIST_PDF).format(now),
+									: Settings.getSimpleDateFormat(CourseParticipantListPDFSettingCodes.NOW_DATE_PATTERN, Bundle.COURSE_PARTICIPANT_LIST_PDF,
+											CourseParticipantListPDFDefaultSettings.NOW_DATE_PATTERN, Locales.COURSE_PARTICIPANT_LIST_PDF,
+											Settings.getBoolean(CourseParticipantListPDFSettingCodes.DATE_USER_TIME_ZONE, Bundle.SETTINGS,
+													CourseParticipantListPDFDefaultSettings.DATE_USER_TIME_ZONE))
+											.format(now),
 							x, y2,
 							PDFUtil.Alignment.TOP_LEFT);
 					y2 -= Settings.getFloat(CourseParticipantListPDFSettingCodes.Y_FRAME_INDENT, Bundle.COURSE_PARTICIPANT_LIST_PDF,

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/CourseParticipantListPDFDefaultSettings.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/CourseParticipantListPDFDefaultSettings.java
@@ -43,6 +43,8 @@ public final class CourseParticipantListPDFDefaultSettings {
 	public static final boolean SHOW_PAGE_NUMBERS = true;
 	public static final String PAINTER_CLASS = null;
 	public static final ArrayList<String> PAINTER_SOURCE_FILES = null;
+	public static final boolean DATE_TIME_USER_TIME_ZONE = true;
+	public static final boolean DATE_USER_TIME_ZONE = true;
 
 	private CourseParticipantListPDFDefaultSettings() {
 	}

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/CourseParticipantListPDFDefaultSettings.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/CourseParticipantListPDFDefaultSettings.java
@@ -28,9 +28,9 @@ public final class CourseParticipantListPDFDefaultSettings {
 	public static final float BLOCKS_LOWER_MARGIN = PAGE_LOWER_MARGIN + Math.max(Y_FRAME_INDENT, Y_PARTICIPANT_TABLE_FRAME_INDENT) + 10.0f;
 	public static final float BLOCKS_LEFT_MARGIN = PAGE_LEFT_MARGIN + Math.max(X_FRAME_INDENT, X_PARTICIPANT_TABLE_FRAME_INDENT);
 	public static final float BLOCKS_RIGHT_MARGIN = PAGE_RIGHT_MARGIN + Math.max(X_FRAME_INDENT, X_PARTICIPANT_TABLE_FRAME_INDENT);
-	public static final String NOW_DATE_TIME_PATTERN = "d. MMMM yyyy";
+	public static final String NOW_DATE_PATTERN = "d. MMMM yyyy";
 	public static final String BOOKING_DATE_TIME_PATTERN = "d. MMMM yyyy HH:mm";
-	public static final String COURSE_DATE_TIME_PATTERN = "d. MMMM yyyy";
+	public static final String COURSE_DATE_PATTERN = "d. MMMM yyyy";
 	public static final Color TEXT_COLOR = Color.BLACK;
 	public static final Color FRAME_COLOR = Color.BLACK;
 	public static final Color PARTICIPANT_TABLE_TEXT_COLOR = Color.BLACK;

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/CourseParticipantListPDFSettingCodes.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/CourseParticipantListPDFSettingCodes.java
@@ -3,8 +3,8 @@ package org.phoenixctms.ctsms.pdf;
 public interface CourseParticipantListPDFSettingCodes {
 
 	public final static String GRAPH_MAX_COURSE_INSTANCES = "graph_max_course_instances";
-	public final static String NOW_DATE_TIME_PATTERN = "now_date_time_pattern";
-	public final static String COURSE_DATE_TIME_PATTERN = "course_date_time_pattern";
+	public final static String NOW_DATE_PATTERN = "now_date_pattern";
+	public final static String COURSE_DATE_PATTERN = "course_date_pattern";
 	public final static String BOOKING_DATE_TIME_PATTERN = "booking_date_time_pattern";
 	public final static String TEMPLATE_FILE_NAME = "template_file_name";
 	public final static String FONT_A = "font_a";

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/CourseParticipantListPDFSettingCodes.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/CourseParticipantListPDFSettingCodes.java
@@ -43,4 +43,6 @@ public interface CourseParticipantListPDFSettingCodes {
 	public static final String SHOW_PAGE_NUMBERS = "show_page_numbers";
 	public static final String PAINTER_CLASS = "painter_class";
 	public static final String PAINTER_SOURCE_FILES = "painter_source_files";
+	public static final String DATE_TIME_USER_TIME_ZONE = "date_time_user_time_zone";
+	public static final String DATE_USER_TIME_ZONE = "date_user_time_zone";
 }

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/EcrfPDFBlock.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/EcrfPDFBlock.java
@@ -55,12 +55,14 @@ public class EcrfPDFBlock extends InputFieldPDFBlock {
 
 		@Override
 		protected DateFormat getDateFormat(boolean isUserTimeZone) {
-			return Settings.getSimpleDateFormat(EcrfPDFSettingCodes.DATE_VALUE_PATTERN, Bundle.ECRF_PDF, EcrfPDFDefaultSettings.DATE_VALUE_PATTERN, Locales.ECRF_PDF);
+			return Settings.getSimpleDateFormat(EcrfPDFSettingCodes.DATE_VALUE_PATTERN, Bundle.ECRF_PDF, EcrfPDFDefaultSettings.DATE_VALUE_PATTERN, Locales.ECRF_PDF,
+					isUserTimeZone);
 		}
 
 		@Override
 		protected DateFormat getDateTimeFormat(boolean isUserTimeZone) {
-			return Settings.getSimpleDateFormat(EcrfPDFSettingCodes.TIMESTAMP_VALUE_PATTERN, Bundle.ECRF_PDF, EcrfPDFDefaultSettings.TIMESTAMP_VALUE_PATTERN, Locales.ECRF_PDF);
+			return Settings.getSimpleDateFormat(EcrfPDFSettingCodes.TIMESTAMP_VALUE_PATTERN, Bundle.ECRF_PDF, EcrfPDFDefaultSettings.TIMESTAMP_VALUE_PATTERN, Locales.ECRF_PDF,
+					isUserTimeZone);
 		}
 
 		@Override
@@ -110,7 +112,8 @@ public class EcrfPDFBlock extends InputFieldPDFBlock {
 
 		@Override
 		protected DateFormat getTimeFormat(boolean isUserTimeZone) {
-			return Settings.getSimpleDateFormat(EcrfPDFSettingCodes.TIME_VALUE_PATTERN, Bundle.ECRF_PDF, EcrfPDFDefaultSettings.TIME_VALUE_PATTERN, Locales.ECRF_PDF);
+			return Settings.getSimpleDateFormat(EcrfPDFSettingCodes.TIME_VALUE_PATTERN, Bundle.ECRF_PDF, EcrfPDFDefaultSettings.TIME_VALUE_PATTERN, Locales.ECRF_PDF,
+					isUserTimeZone);
 		}
 
 		@Override
@@ -237,8 +240,8 @@ public class EcrfPDFBlock extends InputFieldPDFBlock {
 	}
 
 	@Override
-	protected SimpleDateFormat getDateValueFormat() {
-		return Settings.getSimpleDateFormat(EcrfPDFSettingCodes.DATE_VALUE_PATTERN, Bundle.ECRF_PDF, EcrfPDFDefaultSettings.DATE_VALUE_PATTERN, Locales.ECRF_PDF);
+	protected SimpleDateFormat getDateValueFormat(boolean isUserTimeZone) {
+		return Settings.getSimpleDateFormat(EcrfPDFSettingCodes.DATE_VALUE_PATTERN, Bundle.ECRF_PDF, EcrfPDFDefaultSettings.DATE_VALUE_PATTERN, Locales.ECRF_PDF, isUserTimeZone);
 	}
 
 	@Override
@@ -354,7 +357,8 @@ public class EcrfPDFBlock extends InputFieldPDFBlock {
 
 	@Override
 	protected SimpleDateFormat getModifiedTimestampFormat() {
-		return Settings.getSimpleDateFormat(EcrfPDFSettingCodes.MODIFIED_TIMESTAMP_PATTERN, Bundle.ECRF_PDF, EcrfPDFDefaultSettings.MODIFIED_TIMESTAMP_PATTERN, Locales.ECRF_PDF);
+		return Settings.getSimpleDateFormat(EcrfPDFSettingCodes.MODIFIED_TIMESTAMP_PATTERN, Bundle.ECRF_PDF, EcrfPDFDefaultSettings.MODIFIED_TIMESTAMP_PATTERN, Locales.ECRF_PDF,
+				Settings.getBoolean(EcrfPDFSettingCodes.DATE_TIME_USER_TIME_ZONE, Bundle.SETTINGS, EcrfPDFDefaultSettings.DATE_TIME_USER_TIME_ZONE));
 	}
 
 	@Override
@@ -430,8 +434,9 @@ public class EcrfPDFBlock extends InputFieldPDFBlock {
 	}
 
 	@Override
-	protected SimpleDateFormat getTimestampValueFormat() {
-		return Settings.getSimpleDateFormat(EcrfPDFSettingCodes.TIMESTAMP_VALUE_PATTERN, Bundle.ECRF_PDF, EcrfPDFDefaultSettings.TIMESTAMP_VALUE_PATTERN, Locales.ECRF_PDF);
+	protected SimpleDateFormat getTimestampValueFormat(boolean isUserTimeZone) {
+		return Settings.getSimpleDateFormat(EcrfPDFSettingCodes.TIMESTAMP_VALUE_PATTERN, Bundle.ECRF_PDF, EcrfPDFDefaultSettings.TIMESTAMP_VALUE_PATTERN, Locales.ECRF_PDF,
+				isUserTimeZone);
 	}
 
 	@Override
@@ -445,8 +450,8 @@ public class EcrfPDFBlock extends InputFieldPDFBlock {
 	}
 
 	@Override
-	protected SimpleDateFormat getTimeValueFormat() {
-		return Settings.getSimpleDateFormat(EcrfPDFSettingCodes.TIME_VALUE_PATTERN, Bundle.ECRF_PDF, EcrfPDFDefaultSettings.TIME_VALUE_PATTERN, Locales.ECRF_PDF);
+	protected SimpleDateFormat getTimeValueFormat(boolean isUserTimeZone) {
+		return Settings.getSimpleDateFormat(EcrfPDFSettingCodes.TIME_VALUE_PATTERN, Bundle.ECRF_PDF, EcrfPDFDefaultSettings.TIME_VALUE_PATTERN, Locales.ECRF_PDF, isUserTimeZone);
 	}
 
 	@Override
@@ -570,7 +575,8 @@ public class EcrfPDFBlock extends InputFieldPDFBlock {
 										EcrfPDFSettingCodes.PROBAND_DATE_OF_BIRTH_DATE_PATTERN,
 										Bundle.ECRF_PDF,
 										EcrfPDFDefaultSettings.PROBAND_DATE_OF_BIRTH_DATE_PATTERN,
-										Locales.ECRF_PDF).format(listEntry.getProband().getDateOfBirth()) : "",
+										Locales.ECRF_PDF) //no usertimezone
+										.format(listEntry.getProband().getDateOfBirth()) : "",
 								listEntry.getProband().getYearOfBirth() != null ? Integer.toString(listEntry.getProband().getYearOfBirth()) : "",
 								listEntry.getProband().getAge() != null ? Integer.toString(listEntry.getProband().getAge()) : ""),
 						cursor.getBlockX(),
@@ -646,7 +652,8 @@ public class EcrfPDFBlock extends InputFieldPDFBlock {
 												EcrfPDFSettingCodes.PROBAND_DATE_OF_BIRTH_DATE_PATTERN,
 												Bundle.ECRF_PDF,
 												EcrfPDFDefaultSettings.PROBAND_DATE_OF_BIRTH_DATE_PATTERN,
-												Locales.ECRF_PDF).format(listEntry.getProband().getDateOfBirth()) : "",
+												Locales.ECRF_PDF) //no usertimezone
+												.format(listEntry.getProband().getDateOfBirth()) : "",
 										listEntry.getProband().getYearOfBirth() != null ? Integer.toString(listEntry.getProband().getYearOfBirth()) : "",
 										listEntry.getProband().getAge() != null ? Integer.toString(listEntry.getProband().getAge()) : ""),
 								x + getXFrameIndent(),
@@ -741,7 +748,8 @@ public class EcrfPDFBlock extends InputFieldPDFBlock {
 								EcrfPDFSettingCodes.CONTENT_TIMESTAMP_DATETIME_PATTERN,
 								Bundle.ECRF_PDF,
 								EcrfPDFDefaultSettings.CONTENT_TIMESTAMP_DATETIME_PATTERN,
-								Locales.ECRF_PDF).format(now)),
+								Locales.ECRF_PDF,
+								Settings.getBoolean(EcrfPDFSettingCodes.DATE_TIME_USER_TIME_ZONE, Bundle.SETTINGS, EcrfPDFDefaultSettings.DATE_TIME_USER_TIME_ZONE)).format(now)),
 						x + getXFrameIndent(),
 						y,
 						Alignment.TOP_LEFT,

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/EcrfPDFDefaultSettings.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/EcrfPDFDefaultSettings.java
@@ -78,6 +78,7 @@ public final class EcrfPDFDefaultSettings {
 	public static final boolean AUDIT_TRAIL = true;
 	public static final String PAINTER_CLASS = null;
 	public static final ArrayList<String> PAINTER_SOURCE_FILES = null;
+	public static final boolean DATE_TIME_USER_TIME_ZONE = true;
 	static {
 		ECRF_FIELD_STATUS_QUEUES.add("VALIDATION");
 		ECRF_FIELD_STATUS_QUEUES.add("QUERY");

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/EcrfPDFDefaultSettings.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/EcrfPDFDefaultSettings.java
@@ -9,8 +9,8 @@ public final class EcrfPDFDefaultSettings {
 	public static final boolean SHOW_PAGE_NUMBERS = true;
 	public final static boolean LANDSCAPE = false;
 	public static final String PROBAND_DATE_OF_BIRTH_DATE_PATTERN = "d. MMMM yyyy";
-	public static final String CONTENT_TIMESTAMP_DATETIME_PATTERN = "d. MMMM yyyy HH:MM";
-	public static final String MODIFIED_TIMESTAMP_PATTERN = "d. MMMM yyyy HH:MM";
+	public static final String CONTENT_TIMESTAMP_DATETIME_PATTERN = "d. MMMM yyyy HH:mm";
+	public static final String MODIFIED_TIMESTAMP_PATTERN = "d. MMMM yyyy HH:mm";
 	public static final String DECIMAL_SEPARATOR = null;
 	public static final float PAGE_UPPER_MARGIN = 70.0f;
 	public static final float PAGE_LOWER_MARGIN = 60.0f;

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/EcrfPDFSettingCodes.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/EcrfPDFSettingCodes.java
@@ -91,4 +91,5 @@ public interface EcrfPDFSettingCodes {
 	public static final String SHOW_ALL_PROBAND_LIST_ENTRY_TAGS = "show_all_proband_list_entry_tags";
 	public static final String PAINTER_CLASS = "painter_class";
 	public static final String PAINTER_SOURCE_FILES = "painter_source_files";
+	public static final String DATE_TIME_USER_TIME_ZONE = "date_time_user_time_zone";
 }

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/InputFieldPDFBlock.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/InputFieldPDFBlock.java
@@ -78,7 +78,7 @@ public abstract class InputFieldPDFBlock {
 		}
 	}
 
-	protected abstract SimpleDateFormat getDateValueFormat();
+	protected abstract SimpleDateFormat getDateValueFormat(boolean isUserTimeZone);
 
 	protected abstract String getDateValueFormatPattern();
 
@@ -227,6 +227,18 @@ public abstract class InputFieldPDFBlock {
 
 	protected abstract boolean getRenderSketchImages();
 
+	private final boolean getDateTimeUserTimeZone() {
+		return inputField.getUserTimeZone();
+	}
+
+	private final boolean getDateUserTimeZone() {
+		return false;
+	}
+
+	private final boolean getTimeUserTimeZone() {
+		return false;
+	}
+
 	protected abstract String getSelectionSetValueLabel(String name, String value);
 
 	private Map<Long, String> getSelectionSetValueMap() {
@@ -317,7 +329,7 @@ public abstract class InputFieldPDFBlock {
 		}
 	}
 
-	protected abstract SimpleDateFormat getTimestampValueFormat();
+	protected abstract SimpleDateFormat getTimestampValueFormat(boolean isUserTimeZone);
 
 	protected abstract String getTimestampValueFormatPattern();
 
@@ -335,7 +347,7 @@ public abstract class InputFieldPDFBlock {
 		}
 	}
 
-	protected abstract SimpleDateFormat getTimeValueFormat();
+	protected abstract SimpleDateFormat getTimeValueFormat(boolean isUserTimeZone);
 
 	protected abstract String getTimeValueFormatPattern();
 
@@ -484,7 +496,7 @@ public abstract class InputFieldPDFBlock {
 				break;
 			case DATE:
 				value = getDateValue(blank);
-				dateFormat = getDateValueFormat();
+				dateFormat = getDateValueFormat(getDateUserTimeZone());
 				if (value != null) {
 					string = dateFormat.format((Date) value);
 				} else {
@@ -496,7 +508,7 @@ public abstract class InputFieldPDFBlock {
 				break;
 			case TIMESTAMP:
 				value = getTimestampValue(blank);
-				dateFormat = getTimestampValueFormat();
+				dateFormat = getTimestampValueFormat(getDateTimeUserTimeZone());
 				if (value != null) {
 					string = dateFormat.format((Date) value);
 				} else {
@@ -508,7 +520,7 @@ public abstract class InputFieldPDFBlock {
 				break;
 			case TIME:
 				value = getTimeValue(blank);
-				dateFormat = getTimeValueFormat();
+				dateFormat = getTimeValueFormat(getTimeUserTimeZone());
 				if (value != null) {
 					string = dateFormat.format((Date) value);
 				} else {

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/InquiriesPDFBlock.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/InquiriesPDFBlock.java
@@ -107,9 +107,9 @@ public class InquiriesPDFBlock extends InputFieldPDFBlock {
 	}
 
 	@Override
-	protected SimpleDateFormat getDateValueFormat() {
+	protected SimpleDateFormat getDateValueFormat(boolean isUserTimezone) {
 		return Settings.getSimpleDateFormat(InquiriesPDFSettingCodes.DATE_VALUE_PATTERN, Bundle.INQUIRIES_PDF, InquiriesPDFDefaultSettings.DATE_VALUE_PATTERN,
-				Locales.INQUIRIES_PDF);
+				Locales.INQUIRIES_PDF, isUserTimezone);
 	}
 
 	@Override
@@ -217,7 +217,8 @@ public class InquiriesPDFBlock extends InputFieldPDFBlock {
 	@Override
 	protected SimpleDateFormat getModifiedTimestampFormat() {
 		return Settings.getSimpleDateFormat(InquiriesPDFSettingCodes.MODIFIED_TIMESTAMP_PATTERN, Bundle.INQUIRIES_PDF, InquiriesPDFDefaultSettings.MODIFIED_TIMESTAMP_PATTERN,
-				Locales.INQUIRIES_PDF);
+				Locales.INQUIRIES_PDF,
+				Settings.getBoolean(InquiriesPDFSettingCodes.DATE_TIME_USER_TIME_ZONE, Bundle.SETTINGS, InquiriesPDFDefaultSettings.DATE_TIME_USER_TIME_ZONE));
 	}
 
 	@Override
@@ -282,9 +283,9 @@ public class InquiriesPDFBlock extends InputFieldPDFBlock {
 	}
 
 	@Override
-	protected SimpleDateFormat getTimestampValueFormat() {
+	protected SimpleDateFormat getTimestampValueFormat(boolean isUserTimezone) {
 		return Settings.getSimpleDateFormat(InquiriesPDFSettingCodes.TIMESTAMP_VALUE_PATTERN, Bundle.INQUIRIES_PDF, InquiriesPDFDefaultSettings.TIMESTAMP_VALUE_PATTERN,
-				Locales.INQUIRIES_PDF);
+				Locales.INQUIRIES_PDF, isUserTimezone);
 	}
 
 	@Override
@@ -298,9 +299,9 @@ public class InquiriesPDFBlock extends InputFieldPDFBlock {
 	}
 
 	@Override
-	protected SimpleDateFormat getTimeValueFormat() {
+	protected SimpleDateFormat getTimeValueFormat(boolean isUserTimezone) {
 		return Settings.getSimpleDateFormat(InquiriesPDFSettingCodes.TIME_VALUE_PATTERN, Bundle.INQUIRIES_PDF, InquiriesPDFDefaultSettings.TIME_VALUE_PATTERN,
-				Locales.INQUIRIES_PDF);
+				Locales.INQUIRIES_PDF, isUserTimezone);
 	}
 
 	@Override
@@ -427,7 +428,8 @@ public class InquiriesPDFBlock extends InputFieldPDFBlock {
 										InquiriesPDFSettingCodes.PROBAND_DATE_OF_BIRTH_DATE_PATTERN,
 										Bundle.INQUIRIES_PDF,
 										InquiriesPDFDefaultSettings.PROBAND_DATE_OF_BIRTH_DATE_PATTERN,
-										Locales.INQUIRIES_PDF).format(proband.getDateOfBirth()) : "",
+										Locales.INQUIRIES_PDF) //no usertimezone
+										.format(proband.getDateOfBirth()) : "",
 								proband.getYearOfBirth() != null ? Integer.toString(proband.getYearOfBirth())
 										: "",
 								proband.getAge() != null ? Integer.toString(proband.getAge()) : ""),
@@ -451,7 +453,8 @@ public class InquiriesPDFBlock extends InputFieldPDFBlock {
 											InquiriesPDFSettingCodes.PROBAND_DATE_OF_BIRTH_DATE_PATTERN,
 											Bundle.INQUIRIES_PDF,
 											InquiriesPDFDefaultSettings.PROBAND_DATE_OF_BIRTH_DATE_PATTERN,
-											Locales.INQUIRIES_PDF).format(proband.getDateOfBirth()) : "",
+											Locales.INQUIRIES_PDF) //no usertimezone
+											.format(proband.getDateOfBirth()) : "",
 									proband.getYearOfBirth() != null ? Integer.toString(proband.getYearOfBirth()) : "",
 									proband.getAge() != null ? Integer.toString(proband.getAge()) : ""),
 							cursor.getBlockCenterX(),
@@ -507,7 +510,8 @@ public class InquiriesPDFBlock extends InputFieldPDFBlock {
 												InquiriesPDFSettingCodes.PROBAND_DATE_OF_BIRTH_DATE_PATTERN,
 												Bundle.INQUIRIES_PDF,
 												InquiriesPDFDefaultSettings.PROBAND_DATE_OF_BIRTH_DATE_PATTERN,
-												Locales.INQUIRIES_PDF).format(proband.getDateOfBirth()) : "",
+												Locales.INQUIRIES_PDF) //no usertimezone
+												.format(proband.getDateOfBirth()) : "",
 										proband.getYearOfBirth() != null ? Integer.toString(proband.getYearOfBirth()) : "",
 										proband.getAge() != null ? Integer.toString(proband.getAge()) : ""),
 								x + getXFrameIndent(),
@@ -546,7 +550,9 @@ public class InquiriesPDFBlock extends InputFieldPDFBlock {
 								InquiriesPDFSettingCodes.CONTENT_TIMESTAMP_DATETIME_PATTERN,
 								Bundle.INQUIRIES_PDF,
 								InquiriesPDFDefaultSettings.CONTENT_TIMESTAMP_DATETIME_PATTERN,
-								Locales.INQUIRIES_PDF).format(now)),
+								Locales.INQUIRIES_PDF,
+								Settings.getBoolean(InquiriesPDFSettingCodes.DATE_TIME_USER_TIME_ZONE, Bundle.SETTINGS, InquiriesPDFDefaultSettings.DATE_TIME_USER_TIME_ZONE))
+								.format(now)),
 						x + getXFrameIndent(),
 						y,
 						Alignment.TOP_LEFT,

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/InquiriesPDFDefaultSettings.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/InquiriesPDFDefaultSettings.java
@@ -9,8 +9,8 @@ public final class InquiriesPDFDefaultSettings {
 	public static final boolean SHOW_PAGE_NUMBERS = true;
 	public final static boolean LANDSCAPE = false;
 	public static final String PROBAND_DATE_OF_BIRTH_DATE_PATTERN = "d. MMMM yyyy";
-	public static final String CONTENT_TIMESTAMP_DATETIME_PATTERN = "d. MMMM yyyy HH:MM";
-	public static final String MODIFIED_TIMESTAMP_PATTERN = "d. MMMM yyyy HH:MM";
+	public static final String CONTENT_TIMESTAMP_DATETIME_PATTERN = "d. MMMM yyyy HH:mm";
+	public static final String MODIFIED_TIMESTAMP_PATTERN = "d. MMMM yyyy HH:mm";
 	public static final String DECIMAL_SEPARATOR = null;
 	public static final float PAGE_UPPER_MARGIN = 70.0f;
 	public static final float PAGE_LOWER_MARGIN = 60.0f;

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/InquiriesPDFDefaultSettings.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/InquiriesPDFDefaultSettings.java
@@ -71,6 +71,7 @@ public final class InquiriesPDFDefaultSettings {
 	public static final boolean SHOW_MODIFIED_LABEL = false;
 	public static final String PAINTER_CLASS = null;
 	public static final ArrayList<String> PAINTER_SOURCE_FILES = null;
+	public static final boolean DATE_TIME_USER_TIME_ZONE = true;
 
 	private InquiriesPDFDefaultSettings() {
 	}

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/InquiriesPDFSettingCodes.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/InquiriesPDFSettingCodes.java
@@ -84,4 +84,5 @@ public interface InquiriesPDFSettingCodes {
 	public static final String SHOW_MODIFIED_LABEL = "show_modified_label";
 	public static final String PAINTER_CLASS = "painter_class";
 	public static final String PAINTER_SOURCE_FILES = "painter_source_files";
+	public static final String DATE_TIME_USER_TIME_ZONE = "date_time_user_time_zone";
 }

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/ProbandLetterPDFBlock.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/ProbandLetterPDFBlock.java
@@ -194,7 +194,9 @@ public class ProbandLetterPDFBlock {
 						PDFUtil.DEFAULT_LABEL,
 						now == null ? null
 								: Settings.getSimpleDateFormat(ProbandLetterPDFSettingCodes.DATE_PATTERN, Bundle.PROBAND_LETTER_PDF,
-										ProbandLetterPDFDefaultSettings.DATE_PATTERN, Locales.PROBAND_LETTER_PDF).format(now));
+										ProbandLetterPDFDefaultSettings.DATE_PATTERN, Locales.PROBAND_LETTER_PDF,
+										Settings.getBoolean(ProbandLetterPDFSettingCodes.DATE_USER_TIME_ZONE, Bundle.SETTINGS, ProbandLetterPDFDefaultSettings.DATE_USER_TIME_ZONE))
+										.format(now));
 				x = cursor.getBlockX() + cursor.getBlockWidth();
 				y = Settings.getFloat(ProbandLetterPDFSettingCodes.FIRST_PAGE_DATE_Y, Bundle.PROBAND_LETTER_PDF, ProbandLetterPDFDefaultSettings.FIRST_PAGE_DATE_Y);
 				if (!CommonUtil.isEmptyString(line)) {
@@ -222,7 +224,9 @@ public class ProbandLetterPDFBlock {
 						PDFUtil.DEFAULT_LABEL,
 						now == null ? null
 								: Settings.getSimpleDateFormat(ProbandLetterPDFSettingCodes.DATE_PATTERN, Bundle.PROBAND_LETTER_PDF,
-										ProbandLetterPDFDefaultSettings.DATE_PATTERN, Locales.PROBAND_LETTER_PDF).format(now));
+										ProbandLetterPDFDefaultSettings.DATE_PATTERN, Locales.PROBAND_LETTER_PDF,
+										Settings.getBoolean(ProbandLetterPDFSettingCodes.DATE_USER_TIME_ZONE, Bundle.SETTINGS, ProbandLetterPDFDefaultSettings.DATE_USER_TIME_ZONE))
+										.format(now));
 				x = cursor.getBlockX() + cursor.getBlockWidth();
 				y = Settings.getFloat(ProbandLetterPDFSettingCodes.SECOND_PAGE_DATE_Y, Bundle.PROBAND_LETTER_PDF, ProbandLetterPDFDefaultSettings.SECOND_PAGE_DATE_Y);
 				if (!CommonUtil.isEmptyString(line)) {

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/ProbandLetterPDFDefaultSettings.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/ProbandLetterPDFDefaultSettings.java
@@ -28,6 +28,7 @@ public final class ProbandLetterPDFDefaultSettings {
 	public static final float ADDRESS_Y = 680.0f;
 	public static final String PAINTER_CLASS = null;
 	public static final ArrayList<String> PAINTER_SOURCE_FILES = null;
+	public static final boolean DATE_USER_TIME_ZONE = true;
 
 	private ProbandLetterPDFDefaultSettings() {
 	}

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/ProbandLetterPDFSettingCodes.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/ProbandLetterPDFSettingCodes.java
@@ -28,4 +28,5 @@ public interface ProbandLetterPDFSettingCodes {
 	public static final String ADDRESS_Y = "address_y";
 	public static final String PAINTER_CLASS = "painter_class";
 	public static final String PAINTER_SOURCE_FILES = "painter_source_files";
+	public static final String DATE_USER_TIME_ZONE = "date_user_time_zone";
 }

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/ProbandListEntryTagsPDFBlock.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/ProbandListEntryTagsPDFBlock.java
@@ -87,9 +87,9 @@ public class ProbandListEntryTagsPDFBlock extends InputFieldPDFBlock {
 	}
 
 	@Override
-	protected SimpleDateFormat getDateValueFormat() {
+	protected SimpleDateFormat getDateValueFormat(boolean isUserTimezone) {
 		return Settings.getSimpleDateFormat(ProbandListEntryTagsPDFSettingCodes.DATE_VALUE_PATTERN, Bundle.PROBAND_LIST_ENTRY_TAGS_PDF,
-				ProbandListEntryTagsPDFDefaultSettings.DATE_VALUE_PATTERN, Locales.PROBAND_LIST_ENTRY_TAGS_PDF);
+				ProbandListEntryTagsPDFDefaultSettings.DATE_VALUE_PATTERN, Locales.PROBAND_LIST_ENTRY_TAGS_PDF, isUserTimezone);
 	}
 
 	@Override
@@ -210,7 +210,9 @@ public class ProbandListEntryTagsPDFBlock extends InputFieldPDFBlock {
 	@Override
 	protected SimpleDateFormat getModifiedTimestampFormat() {
 		return Settings.getSimpleDateFormat(ProbandListEntryTagsPDFSettingCodes.MODIFIED_TIMESTAMP_PATTERN, Bundle.PROBAND_LIST_ENTRY_TAGS_PDF,
-				ProbandListEntryTagsPDFDefaultSettings.MODIFIED_TIMESTAMP_PATTERN, Locales.PROBAND_LIST_ENTRY_TAGS_PDF);
+				ProbandListEntryTagsPDFDefaultSettings.MODIFIED_TIMESTAMP_PATTERN, Locales.PROBAND_LIST_ENTRY_TAGS_PDF,
+				Settings.getBoolean(ProbandListEntryTagsPDFSettingCodes.DATE_TIME_USER_TIME_ZONE, Bundle.SETTINGS,
+						ProbandListEntryTagsPDFDefaultSettings.DATE_TIME_USER_TIME_ZONE));
 	}
 
 	@Override
@@ -275,9 +277,9 @@ public class ProbandListEntryTagsPDFBlock extends InputFieldPDFBlock {
 	}
 
 	@Override
-	protected SimpleDateFormat getTimestampValueFormat() {
+	protected SimpleDateFormat getTimestampValueFormat(boolean isUserTimezone) {
 		return Settings.getSimpleDateFormat(ProbandListEntryTagsPDFSettingCodes.TIMESTAMP_VALUE_PATTERN, Bundle.PROBAND_LIST_ENTRY_TAGS_PDF,
-				ProbandListEntryTagsPDFDefaultSettings.TIMESTAMP_VALUE_PATTERN, Locales.PROBAND_LIST_ENTRY_TAGS_PDF);
+				ProbandListEntryTagsPDFDefaultSettings.TIMESTAMP_VALUE_PATTERN, Locales.PROBAND_LIST_ENTRY_TAGS_PDF, isUserTimezone);
 	}
 
 	@Override
@@ -292,9 +294,9 @@ public class ProbandListEntryTagsPDFBlock extends InputFieldPDFBlock {
 	}
 
 	@Override
-	protected SimpleDateFormat getTimeValueFormat() {
+	protected SimpleDateFormat getTimeValueFormat(boolean isUserTimezone) {
 		return Settings.getSimpleDateFormat(ProbandListEntryTagsPDFSettingCodes.TIME_VALUE_PATTERN, Bundle.PROBAND_LIST_ENTRY_TAGS_PDF,
-				ProbandListEntryTagsPDFDefaultSettings.TIME_VALUE_PATTERN, Locales.PROBAND_LIST_ENTRY_TAGS_PDF);
+				ProbandListEntryTagsPDFDefaultSettings.TIME_VALUE_PATTERN, Locales.PROBAND_LIST_ENTRY_TAGS_PDF, isUserTimezone);
 	}
 
 	@Override
@@ -430,7 +432,8 @@ public class ProbandListEntryTagsPDFBlock extends InputFieldPDFBlock {
 										ProbandListEntryTagsPDFSettingCodes.PROBAND_DATE_OF_BIRTH_DATE_PATTERN,
 										Bundle.PROBAND_LIST_ENTRY_TAGS_PDF,
 										ProbandListEntryTagsPDFDefaultSettings.PROBAND_DATE_OF_BIRTH_DATE_PATTERN,
-										Locales.PROBAND_LIST_ENTRY_TAGS_PDF).format(listEntry.getProband().getDateOfBirth()) : "",
+										Locales.PROBAND_LIST_ENTRY_TAGS_PDF) //no usertimezone
+										.format(listEntry.getProband().getDateOfBirth()) : "",
 								listEntry.getProband().getYearOfBirth() != null ? Integer.toString(listEntry.getProband().getYearOfBirth()) : "",
 								listEntry.getProband().getAge() != null ? Integer.toString(listEntry.getProband().getAge()) : ""),
 						cursor.getBlockX(),
@@ -455,7 +458,8 @@ public class ProbandListEntryTagsPDFBlock extends InputFieldPDFBlock {
 											ProbandListEntryTagsPDFSettingCodes.PROBAND_DATE_OF_BIRTH_DATE_PATTERN,
 											Bundle.PROBAND_LIST_ENTRY_TAGS_PDF,
 											ProbandListEntryTagsPDFDefaultSettings.PROBAND_DATE_OF_BIRTH_DATE_PATTERN,
-											Locales.PROBAND_LIST_ENTRY_TAGS_PDF).format(listEntry.getProband().getDateOfBirth()) : "",
+											Locales.PROBAND_LIST_ENTRY_TAGS_PDF) //no usertimezone
+											.format(listEntry.getProband().getDateOfBirth()) : "",
 									listEntry.getProband().getYearOfBirth() != null ? Integer.toString(listEntry.getProband().getYearOfBirth()) : "",
 									listEntry.getProband().getAge() != null ? Integer.toString(listEntry.getProband().getAge()) : ""),
 							cursor.getBlockCenterX(),
@@ -520,7 +524,8 @@ public class ProbandListEntryTagsPDFBlock extends InputFieldPDFBlock {
 												ProbandListEntryTagsPDFSettingCodes.PROBAND_DATE_OF_BIRTH_DATE_PATTERN,
 												Bundle.PROBAND_LIST_ENTRY_TAGS_PDF,
 												ProbandListEntryTagsPDFDefaultSettings.PROBAND_DATE_OF_BIRTH_DATE_PATTERN,
-												Locales.PROBAND_LIST_ENTRY_TAGS_PDF).format(listEntry.getProband().getDateOfBirth()) : "",
+												Locales.PROBAND_LIST_ENTRY_TAGS_PDF) //no usertimezone
+												.format(listEntry.getProband().getDateOfBirth()) : "",
 										listEntry.getProband().getYearOfBirth() != null ? Integer.toString(listEntry.getProband().getYearOfBirth()) : "",
 										listEntry.getProband().getAge() != null ? Integer.toString(listEntry.getProband().getAge()) : ""),
 								x + getXFrameIndent(),
@@ -572,7 +577,9 @@ public class ProbandListEntryTagsPDFBlock extends InputFieldPDFBlock {
 												ProbandListEntryTagsPDFSettingCodes.CONTENT_TIMESTAMP_DATETIME_PATTERN,
 												Bundle.PROBAND_LIST_ENTRY_TAGS_PDF,
 												ProbandListEntryTagsPDFDefaultSettings.CONTENT_TIMESTAMP_DATETIME_PATTERN,
-												Locales.PROBAND_LIST_ENTRY_TAGS_PDF)
+												Locales.PROBAND_LIST_ENTRY_TAGS_PDF,
+												Settings.getBoolean(ProbandListEntryTagsPDFSettingCodes.DATE_TIME_USER_TIME_ZONE, Bundle.SETTINGS,
+														ProbandListEntryTagsPDFDefaultSettings.DATE_TIME_USER_TIME_ZONE))
 										.format(now)),
 						x + getXFrameIndent(),
 						y,

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/ProbandListEntryTagsPDFDefaultSettings.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/ProbandListEntryTagsPDFDefaultSettings.java
@@ -9,8 +9,8 @@ public final class ProbandListEntryTagsPDFDefaultSettings {
 	public static final boolean SHOW_PAGE_NUMBERS = true;
 	public final static boolean LANDSCAPE = false;
 	public static final String PROBAND_DATE_OF_BIRTH_DATE_PATTERN = "d. MMMM yyyy";
-	public static final String CONTENT_TIMESTAMP_DATETIME_PATTERN = "d. MMMM yyyy HH:MM";
-	public static final String MODIFIED_TIMESTAMP_PATTERN = "d. MMMM yyyy HH:MM";
+	public static final String CONTENT_TIMESTAMP_DATETIME_PATTERN = "d. MMMM yyyy HH:mm";
+	public static final String MODIFIED_TIMESTAMP_PATTERN = "d. MMMM yyyy HH:mm";
 	public static final float PAGE_UPPER_MARGIN = 70.0f;
 	public static final float PAGE_LOWER_MARGIN = 60.0f;
 	public static final float PAGE_LEFT_MARGIN = 60.0f;

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/ProbandListEntryTagsPDFDefaultSettings.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/ProbandListEntryTagsPDFDefaultSettings.java
@@ -71,6 +71,7 @@ public final class ProbandListEntryTagsPDFDefaultSettings {
 	public static final boolean SHOW_MODIFIED_LABEL = false;
 	public static final String PAINTER_CLASS = null;
 	public static final ArrayList<String> PAINTER_SOURCE_FILES = null;
+	public static final boolean DATE_TIME_USER_TIME_ZONE = true;
 
 	private ProbandListEntryTagsPDFDefaultSettings() {
 	}

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/ProbandListEntryTagsPDFSettingCodes.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/ProbandListEntryTagsPDFSettingCodes.java
@@ -84,4 +84,5 @@ public interface ProbandListEntryTagsPDFSettingCodes {
 	public static final String SHOW_MODIFIED_LABEL = "show_modified_label";
 	public static final String PAINTER_CLASS = "painter_class";
 	public static final String PAINTER_SOURCE_FILES = "painter_source_files";
+	public static final String DATE_TIME_USER_TIME_ZONE = "date_time_user_time_zone";
 }

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/ReimbursementsPDFBlock.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/ReimbursementsPDFBlock.java
@@ -261,7 +261,9 @@ public class ReimbursementsPDFBlock {
 					getProbandName(true, true),
 					now == null ? null
 							: Settings.getSimpleDateFormat(ReimbursementsPDFSettingCodes.SIGNATURE_DATE_PATTERN, Bundle.REIMBURSEMENTS_PDF,
-									ReimbursementsPDFDefaultSettings.SIGNATURE_DATE_PATTERN, Locales.REIMBURSEMENTS_PDF).format(now));
+									ReimbursementsPDFDefaultSettings.SIGNATURE_DATE_PATTERN, Locales.REIMBURSEMENTS_PDF,
+									Settings.getBoolean(ReimbursementsPDFSettingCodes.DATE_USER_TIME_ZONE, Bundle.SETTINGS, ReimbursementsPDFDefaultSettings.DATE_USER_TIME_ZONE))
+									.format(now));
 		}
 		return "";
 	}
@@ -437,7 +439,10 @@ public class ReimbursementsPDFBlock {
 						PDFUtil.DEFAULT_LABEL,
 						now == null ? null
 								: Settings.getSimpleDateFormat(ReimbursementsPDFSettingCodes.DATE_PATTERN, Bundle.REIMBURSEMENTS_PDF,
-										ReimbursementsPDFDefaultSettings.DATE_PATTERN, Locales.REIMBURSEMENTS_PDF).format(now));
+										ReimbursementsPDFDefaultSettings.DATE_PATTERN, Locales.REIMBURSEMENTS_PDF,
+										Settings.getBoolean(ReimbursementsPDFSettingCodes.DATE_USER_TIME_ZONE, Bundle.SETTINGS,
+												ReimbursementsPDFDefaultSettings.DATE_USER_TIME_ZONE))
+										.format(now));
 				x = cursor.getBlockX() + cursor.getBlockWidth();
 				y = Settings.getFloat(ReimbursementsPDFSettingCodes.FIRST_PAGE_DATE_Y, Bundle.REIMBURSEMENTS_PDF, ReimbursementsPDFDefaultSettings.FIRST_PAGE_DATE_Y);
 				if (!CommonUtil.isEmptyString(line)) {
@@ -503,7 +508,10 @@ public class ReimbursementsPDFBlock {
 						PDFUtil.DEFAULT_LABEL,
 						now == null ? null
 								: Settings.getSimpleDateFormat(ReimbursementsPDFSettingCodes.DATE_PATTERN, Bundle.REIMBURSEMENTS_PDF,
-										ReimbursementsPDFDefaultSettings.DATE_PATTERN, Locales.REIMBURSEMENTS_PDF).format(now));
+										ReimbursementsPDFDefaultSettings.DATE_PATTERN, Locales.REIMBURSEMENTS_PDF,
+										Settings.getBoolean(ReimbursementsPDFSettingCodes.DATE_USER_TIME_ZONE, Bundle.SETTINGS,
+												ReimbursementsPDFDefaultSettings.DATE_USER_TIME_ZONE))
+										.format(now));
 				x = cursor.getBlockX() + cursor.getBlockWidth();
 				y = Settings.getFloat(ReimbursementsPDFSettingCodes.SECOND_PAGE_DATE_Y, Bundle.REIMBURSEMENTS_PDF, ReimbursementsPDFDefaultSettings.SECOND_PAGE_DATE_Y);
 				if (!CommonUtil.isEmptyString(line)) {

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/ReimbursementsPDFDefaultSettings.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/ReimbursementsPDFDefaultSettings.java
@@ -55,6 +55,7 @@ public final class ReimbursementsPDFDefaultSettings {
 	public final static float Y_TOTALS_INDENT = 10.0f;
 	public static final String PAINTER_CLASS = null;
 	public static final ArrayList<String> PAINTER_SOURCE_FILES = null;
+	public static final boolean DATE_USER_TIME_ZONE = true;
 
 	private ReimbursementsPDFDefaultSettings() {
 	}

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/ReimbursementsPDFSettingCodes.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/ReimbursementsPDFSettingCodes.java
@@ -56,4 +56,5 @@ public interface ReimbursementsPDFSettingCodes {
 	public static final String Y_TOTALS_INDENT = "y_totals_indent";
 	public static final String PAINTER_CLASS = "painter_class";
 	public static final String PAINTER_SOURCE_FILES = "painter_source_files";
+	public static final String DATE_USER_TIME_ZONE = "date_user_time_zone";
 }

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/TrainingRecordPDFBlock.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/TrainingRecordPDFBlock.java
@@ -149,7 +149,9 @@ public class TrainingRecordPDFBlock {
 	protected static String getCourseStopString(CourseOutVO course) {
 		if (course != null) {
 			return Settings.getSimpleDateFormat(TrainingRecordPDFSettingCodes.COURSE_STOP_DATE_PATTERN, Bundle.TRAINING_RECORD_PDF,
-					TrainingRecordPDFDefaultSettings.COURSE_STOP_DATE_PATTERN, Locales.TRAINING_RECORD_PDF).format(course.getStop());
+					TrainingRecordPDFDefaultSettings.COURSE_STOP_DATE_PATTERN, Locales.TRAINING_RECORD_PDF,
+					Settings.getBoolean(TrainingRecordPDFSettingCodes.DATE_USER_TIME_ZONE, Bundle.SETTINGS, TrainingRecordPDFDefaultSettings.DATE_USER_TIME_ZONE))
+					.format(course.getStop());
 		}
 		return "";
 	}

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/TrainingRecordPDFDefaultSettings.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/TrainingRecordPDFDefaultSettings.java
@@ -61,6 +61,7 @@ public final class TrainingRecordPDFDefaultSettings {
 	public static final String PAINTER_CLASS = null;
 	public static final boolean INSTITUTION_STAFF_PATH = true;
 	public static final ArrayList<String> PAINTER_SOURCE_FILES = null;
+	public static final boolean DATE_USER_TIME_ZONE = true;
 
 	private TrainingRecordPDFDefaultSettings() {
 	}

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/TrainingRecordPDFPainter.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/TrainingRecordPDFPainter.java
@@ -77,7 +77,9 @@ public class TrainingRecordPDFPainter extends PDFPainterBase implements PDFOutpu
 					now == null ? null
 							: Settings
 									.getSimpleDateFormat(TrainingRecordPDFSettingCodes.SIGNATURE_DATE_PATTERN, Bundle.TRAINING_RECORD_PDF,
-											TrainingRecordPDFDefaultSettings.SIGNATURE_DATE_PATTERN, Locales.TRAINING_RECORD_PDF)
+											TrainingRecordPDFDefaultSettings.SIGNATURE_DATE_PATTERN, Locales.TRAINING_RECORD_PDF,
+											Settings.getBoolean(TrainingRecordPDFSettingCodes.DATE_USER_TIME_ZONE, Bundle.SETTINGS,
+													TrainingRecordPDFDefaultSettings.DATE_USER_TIME_ZONE))
 									.format(now));
 		}
 		return "";
@@ -90,7 +92,9 @@ public class TrainingRecordPDFPainter extends PDFPainterBase implements PDFOutpu
 					now == null ? null
 							: Settings
 									.getSimpleDateFormat(TrainingRecordPDFSettingCodes.SIGNATURE_DATE_PATTERN, Bundle.TRAINING_RECORD_PDF,
-											TrainingRecordPDFDefaultSettings.SIGNATURE_DATE_PATTERN, Locales.TRAINING_RECORD_PDF)
+											TrainingRecordPDFDefaultSettings.SIGNATURE_DATE_PATTERN, Locales.TRAINING_RECORD_PDF,
+											Settings.getBoolean(TrainingRecordPDFSettingCodes.DATE_USER_TIME_ZONE, Bundle.SETTINGS,
+													TrainingRecordPDFDefaultSettings.DATE_USER_TIME_ZONE))
 									.format(now));
 		}
 		return "";

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/TrainingRecordPDFSettingCodes.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/TrainingRecordPDFSettingCodes.java
@@ -63,4 +63,6 @@ public interface TrainingRecordPDFSettingCodes {
 	public static final String PAINTER_SOURCE_FILES = "painter_source_files";
 	public static final String INSTITUTION_STAFF_PATH = "institution_staff_path";
 	public static final String PASSED_COURSES_ONLY = "passed_courses_only";
+	public static final String USER_TIME_ZONE = "user_time_zone";
+	public static final String DATE_USER_TIME_ZONE = "date_user_time_zone";
 }

--- a/core/src/main/java/org/phoenixctms/ctsms/util/Settings.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/util/Settings.java
@@ -482,6 +482,14 @@ public final class Settings {
 		}
 	}
 
+	public static SimpleDateFormat getSimpleDateFormat(String key, Bundle bundle, String defaultValue, Locales locale, boolean isUserTimezone) {
+		SimpleDateFormat dateFormat = getSimpleDateFormat(key, bundle, defaultValue, locale);
+		if (isUserTimezone) {
+			dateFormat.setTimeZone(CoreUtil.getUserContext().getTimeZone());
+		}
+		return dateFormat;
+	}
+
 	public static String getString(String key, Bundle bundle, String defaultValue) {
 		return CommonUtil.getValue(key, getBundle(bundle), defaultValue);
 	}

--- a/core/src/main/resources/ctsms-coursecertificate-pdf-settings.properties
+++ b/core/src/main/resources/ctsms-coursecertificate-pdf-settings.properties
@@ -4,7 +4,7 @@
 
 graph_max_staff_instances=10
 
-course_date_time_pattern=d. MMMM yyyy
+course_date_pattern=d. MMMM yyyy
 
 template_file_name=/ctsms/pdf_templates/coursecertificate_template.pdf
 #template_file_name=C\:\\ctsms\\pdf_templates\\coursecertificate_template.pdf
@@ -38,3 +38,5 @@ blocks_left_margin=55.5
 blocks_right_margin=55.5
 
 text_color=BLACK
+
+date_user_time_zone=true

--- a/core/src/main/resources/ctsms-courseparticipantlist-pdf-settings.properties
+++ b/core/src/main/resources/ctsms-courseparticipantlist-pdf-settings.properties
@@ -4,8 +4,8 @@
 
 graph_max_course_instances=1
 
-now_date_time_pattern=d. MMMM yyyy
-course_date_time_pattern=d. MMMM yyyy
+now_date_pattern=d. MMMM yyyy
+course_date_pattern=d. MMMM yyyy
 booking_date_time_pattern=d. MMMM yyyy HH:mm
 template_file_name=/ctsms/pdf_templates/courseparticipantlist_template.pdf
 #template_file_name=C\:\\ctsms\\pdf_templates\\courseparticipantlist_template.pdf
@@ -60,3 +60,6 @@ participant_table_column_lecturer_signature_width=110.0
 participant_table_column_participant_signature_width=110.0
 
 blank_rows=10
+
+date_time_user_time_zone=true
+date_user_time_zone=true

--- a/core/src/main/resources/ctsms-cv-pdf-settings.properties
+++ b/core/src/main/resources/ctsms-cv-pdf-settings.properties
@@ -70,3 +70,5 @@ text_color=BLACK
 frame_color=BLACK
 
 passed_courses_only=true
+
+date_user_time_zone=true

--- a/core/src/main/resources/ctsms-ecrf-pdf-settings.properties
+++ b/core/src/main/resources/ctsms-ecrf-pdf-settings.properties
@@ -130,3 +130,4 @@ sketch_image_bg_color=
 render_sketch_images=true
 show_sketch_regions=false
 
+date_time_user_time_zone=true

--- a/core/src/main/resources/ctsms-ecrf-pdf-settings.properties
+++ b/core/src/main/resources/ctsms-ecrf-pdf-settings.properties
@@ -15,8 +15,8 @@ font_d=Courier-Bold
 #Helvetica-Oblique
 
 proband_date_of_birth_date_pattern=d. MMMM yyyy
-content_timestamp_datetime_pattern=d. MMMM yyyy HH:MM
-modified_timestamp_pattern=d. MMMM yyyy HH:MM
+content_timestamp_datetime_pattern=d. MMMM yyyy HH:mm
+modified_timestamp_pattern=d. MMMM yyyy HH:mm
 
 landscape=false
 show_page_numbers=true

--- a/core/src/main/resources/ctsms-inquiries-pdf-settings.properties
+++ b/core/src/main/resources/ctsms-inquiries-pdf-settings.properties
@@ -15,8 +15,8 @@ font_d=Courier-Bold
 #Helvetica-Oblique
 
 proband_date_of_birth_date_pattern=d. MMMM yyyy
-content_timestamp_datetime_pattern=d. MMMM yyyy HH:MM
-modified_timestamp_pattern=d. MMMM yyyy HH:MM
+content_timestamp_datetime_pattern=d. MMMM yyyy HH:mm
+modified_timestamp_pattern=d. MMMM yyyy HH:mm
 
 landscape=false
 show_page_numbers=true

--- a/core/src/main/resources/ctsms-inquiries-pdf-settings.properties
+++ b/core/src/main/resources/ctsms-inquiries-pdf-settings.properties
@@ -121,3 +121,5 @@ sketch_image_dpi=144
 sketch_image_bg_color=
 render_sketch_images=true
 show_sketch_regions=false
+
+date_time_user_time_zone=true

--- a/core/src/main/resources/ctsms-probandletter-pdf-settings.properties
+++ b/core/src/main/resources/ctsms-probandletter-pdf-settings.properties
@@ -43,3 +43,5 @@ text_color=BLACK
 #frame_color=BLACK
 
 proband_id_y=89.31
+
+date_user_time_zone=true

--- a/core/src/main/resources/ctsms-probandlistentrytags-pdf-settings.properties
+++ b/core/src/main/resources/ctsms-probandlistentrytags-pdf-settings.properties
@@ -15,8 +15,8 @@ font_d=Courier-Bold
 #Helvetica-Oblique
 
 proband_date_of_birth_date_pattern=d. MMMM yyyy
-content_timestamp_datetime_pattern=d. MMMM yyyy HH:MM
-modified_timestamp_pattern=d. MMMM yyyy HH:MM
+content_timestamp_datetime_pattern=d. MMMM yyyy HH:mm
+modified_timestamp_pattern=d. MMMM yyyy HH:mm
 
 landscape=false
 show_page_numbers=true

--- a/core/src/main/resources/ctsms-probandlistentrytags-pdf-settings.properties
+++ b/core/src/main/resources/ctsms-probandlistentrytags-pdf-settings.properties
@@ -121,3 +121,5 @@ sketch_image_dpi=144
 sketch_image_bg_color=
 render_sketch_images=true
 show_sketch_regions=false
+
+date_time_user_time_zone=true

--- a/core/src/main/resources/ctsms-reimbursements-pdf-settings.properties
+++ b/core/src/main/resources/ctsms-reimbursements-pdf-settings.properties
@@ -1,4 +1,6 @@
 
+#painter_class=org.phoenixctms.ctsms.pdf.MyCvPDFPainter
+#painter_source_files=org/phoenixctms/ctsms/pdf/MyCvPDFBlock.java,org/phoenixctms/ctsms/pdf/MyCvPDFBlockCursor.java,org/phoenixctms/ctsms/pdf/MyCvPDFDefaultSettings.java,org/phoenixctms/ctsms/pdf/MyCvPDFLabelCodes.java,org/phoenixctms/ctsms/pdf/MyCvPDFPainter.java,org/phoenixctms/ctsms/pdf/MyCvPDFSettingCodes.java
 
 date_pattern=d. MMMM yyyy
 
@@ -75,3 +77,5 @@ signature_date_pattern=d. MMMM yyyy
 payment_table_row_height_limit=220.0f
 #215 min.
 y_totals_indent=10.0
+
+date_user_time_zone=true

--- a/core/src/main/resources/ctsms-trainingrecord-pdf-settings.properties
+++ b/core/src/main/resources/ctsms-trainingrecord-pdf-settings.properties
@@ -85,3 +85,5 @@ frame_color=BLACK
 
 institution_staff_path=true
 passed_courses_only=true
+
+date_user_time_zone=true

--- a/pom.xml
+++ b/pom.xml
@@ -327,7 +327,7 @@
 			<dependency>
 				<groupId>org.postgresql</groupId>
 				<artifactId>postgresql</artifactId>
-				<version>42.2.2.jre7</version>
+				<version>42.2.2</version>
 			</dependency>
 
 			<dependency>

--- a/web/src/main/resources/org/phoenixctms/ctsms/web/inputfield/labels.properties
+++ b/web/src/main/resources/org/phoenixctms/ctsms/web/inputfield/labels.properties
@@ -119,7 +119,7 @@ input_field_timestamp_preset=Timestamp preset
 input_field_timestamp_preset_tooltip=A timestamp (date plus time of day part) preset value is optional.
 
 input_field_usertimezone_label=User time zone input\:
-input_field_usertimezone_tooltip=Timestamps are provided in the time zone of the user instead of system time ({0}).
+input_field_usertimezone_tooltip=Timestamps will be entered in user's time zone rather than system time ({0}).
 
 input_field_min_time_label=Minimum time:
 input_field_min_time=Minimum time


### PR DESCRIPTION
so far, the implementation uses the UserTimezone setting in the JSF UI layer only:

-    the database contains values in application timezone (eg. UTC)
-    forward: datetime values are converted into UserTImezone when dispalying it in the UI
-    backward: entered values are converted back from UserTimezon into application timezone

so the proper solution here is to complete the implementation:

1.    implement the forward timezone conversion also in the PDF renderers
2.    implement the forward timezone conversion also in the Excel renderers
3.    implement the forward timezone conversion also for the rest-api response objects (to have it in the exports as desired)

this PR covers point 1. above.

