### PR TITLE
improve search result loading times

### DIFF
--- a/common/src/main/java/org/phoenixctms/ctsms/util/CommonUtil.java
+++ b/common/src/main/java/org/phoenixctms/ctsms/util/CommonUtil.java
@@ -1140,15 +1140,30 @@ public final class CommonUtil {
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <T> T getDeclaredFieldValue(Object object, String fieldName) {
+	private static <T> T getDeclaredFieldValue(Object object, String fieldName, Class clazz) {
 		//https://stackoverflow.com/questions/4325164/how-to-reload-resource-bundle-in-web-application
 		try {
-			Field field = object.getClass().getDeclaredField(fieldName);
+			Field field = clazz.getDeclaredField(fieldName);
 			field.setAccessible(true);
 			return (T) field.get(object);
 		} catch (Exception e) {
 			return null;
 		}
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> T getDeclaredFieldValue(Object object, String fieldName) {
+		return getDeclaredFieldValue(object, fieldName, object.getClass());
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> T getDeclaredFieldValue(Object object, Class superClass, String fieldName) {
+		//https://stackoverflow.com/questions/15420968/nosuchfieldexception-when-field-exists/69946642#69946642
+		Class clazz = object.getClass();
+		while (clazz != null && !clazz.equals(superClass)) {
+			clazz = clazz.getSuperclass();
+		}
+		return getDeclaredFieldValue(object, fieldName, clazz);
 	}
 
 	public static Long getEntityPosition(Object entity) throws Exception {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/component/datatable/DataTable.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/component/datatable/DataTable.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 
+import org.phoenixctms.ctsms.util.CommonUtil;
 import org.phoenixctms.ctsms.web.model.LazyDataModel;
 import org.phoenixctms.ctsms.web.util.WebUtil;
 import org.primefaces.component.column.Column;
@@ -159,6 +160,18 @@ public class DataTable extends org.primefaces.component.datatable.DataTable {
 			//} else {
 			//	System.out.println("cannot find: " + id);
 		}
+	}
+
+	public String getClientId() {
+		FacesContext context = FacesContext.getCurrentInstance();
+		return getClientId(context);
+	}
+
+	public static boolean isRowExpansionRequest(String id) {
+		DataTable dataTable = (DataTable) WebUtil.findComponentById(id);
+		String clientId = CommonUtil.getDeclaredFieldValue(dataTable, "baseClientId");
+		FacesContext context = FacesContext.getCurrentInstance();
+		return context.getExternalContext().getRequestParameterMap().containsKey(clientId + "_rowExpansion");
 	}
 
 	private boolean usePageFromDataModel() {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/component/datatable/DataTable.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/component/datatable/DataTable.java
@@ -162,14 +162,9 @@ public class DataTable extends org.primefaces.component.datatable.DataTable {
 		}
 	}
 
-	public String getClientId() {
-		FacesContext context = FacesContext.getCurrentInstance();
-		return getClientId(context);
-	}
-
 	public static boolean isRowExpansionRequest(String id) {
 		DataTable dataTable = (DataTable) WebUtil.findComponentById(id);
-		String clientId = CommonUtil.getDeclaredFieldValue(dataTable, "baseClientId");
+		String clientId = CommonUtil.getDeclaredFieldValue(dataTable, javax.faces.component.UIData.class, "baseClientId");
 		FacesContext context = FacesContext.getCurrentInstance();
 		return context.getExternalContext().getRequestParameterMap().containsKey(clientId + "_rowExpansion");
 	}

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/InputFieldSearchBean.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/InputFieldSearchBean.java
@@ -93,7 +93,7 @@ public class InputFieldSearchBean extends SearchBeanBase {
 	}
 
 	public Collection<IDVO> getEcrfFields(InputFieldOutVO inputField) {
-		if (inputField != null) {
+		if (inputField != null && DataTable.isRowExpansionRequest(getResultListId())) {
 			if (!ecrfFieldCache.containsKey(inputField.getId())) {
 				Collection ecrfFields = null;
 				try {
@@ -161,7 +161,7 @@ public class InputFieldSearchBean extends SearchBeanBase {
 	}
 
 	public Collection<IDVO> getInquiries(InputFieldOutVO inputField) {
-		if (inputField != null) {
+		if (inputField != null && DataTable.isRowExpansionRequest(getResultListId())) {
 			if (!inquiryCache.containsKey(inputField.getId())) {
 				Collection inquiries = null;
 				try {
@@ -207,7 +207,7 @@ public class InputFieldSearchBean extends SearchBeanBase {
 	}
 
 	public Collection<IDVO> getProbandListEntryTags(InputFieldOutVO inputField) {
-		if (inputField != null) {
+		if (inputField != null && DataTable.isRowExpansionRequest(getResultListId())) {
 			if (!listEntryTagCache.containsKey(inputField.getId())) {
 				Collection probandListEntryTags = null;
 				try {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/ProbandSearchBean.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/ProbandSearchBean.java
@@ -100,7 +100,7 @@ public class ProbandSearchBean extends SearchBeanBase {
 	}
 
 	public Collection<IDVO> getProbandAddresses(ProbandOutVO proband) {
-		if (proband != null) {
+		if (proband != null && DataTable.isRowExpansionRequest(getResultListId())) {
 			if (!probandAddressCache.containsKey(proband.getId())) {
 				Collection probandAddresses = null;
 				try {
@@ -123,7 +123,7 @@ public class ProbandSearchBean extends SearchBeanBase {
 	}
 
 	public Collection<IDVO> getProbandContactDetailValues(ProbandOutVO proband) {
-		if (proband != null) {
+		if (proband != null && DataTable.isRowExpansionRequest(getResultListId())) {
 			if (!probandContactDetailValueCache.containsKey(proband.getId())) {
 				Collection probandContactDetailValues = null;
 				try {
@@ -162,7 +162,7 @@ public class ProbandSearchBean extends SearchBeanBase {
 	}
 
 	public Collection<IDVO> getProbandListStatus(ProbandOutVO proband) {
-		if (proband != null) {
+		if (proband != null && DataTable.isRowExpansionRequest(getResultListId())) {
 			if (!probandListStatusCache.containsKey(proband.getId())) {
 				Collection probandListStatus = null;
 				try {
@@ -189,7 +189,7 @@ public class ProbandSearchBean extends SearchBeanBase {
 	}
 
 	public Collection<IDVO> getProbandTagValues(ProbandOutVO proband) {
-		if (proband != null) {
+		if (proband != null && DataTable.isRowExpansionRequest(getResultListId())) {
 			if (!probandTagValueCache.containsKey(proband.getId())) {
 				Collection probandTagValues = null;
 				try {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/StaffSearchBean.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/StaffSearchBean.java
@@ -147,7 +147,7 @@ public class StaffSearchBean extends SearchBeanBase {
 	}
 
 	public Collection<IDVO> getStaffAddresses(StaffOutVO staff) {
-		if (staff != null) {
+		if (staff != null && DataTable.isRowExpansionRequest(getResultListId())) {
 			if (!staffAddressCache.containsKey(staff.getId())) {
 				Collection staffAddresses = null;
 				try {
@@ -170,7 +170,7 @@ public class StaffSearchBean extends SearchBeanBase {
 	}
 
 	public Collection<IDVO> getStaffContactDetailValues(StaffOutVO staff) {
-		if (staff != null) {
+		if (staff != null && DataTable.isRowExpansionRequest(getResultListId())) {
 			if (!staffContactDetailValueCache.containsKey(staff.getId())) {
 				Collection staffContactDetailValues = null;
 				try {
@@ -198,7 +198,7 @@ public class StaffSearchBean extends SearchBeanBase {
 	}
 
 	public Collection<IDVO> getStaffTagValues(StaffOutVO staff) {
-		if (staff != null) {
+		if (staff != null && DataTable.isRowExpansionRequest(getResultListId())) {
 			if (!staffTagValueCache.containsKey(staff.getId())) {
 				Collection staffTagValues = null;
 				try {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/TrialSearchBean.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/search/TrialSearchBean.java
@@ -124,7 +124,7 @@ public class TrialSearchBean extends SearchBeanBase {
 	}
 
 	public Collection<IDVO> getTeamMembers(TrialOutVO trial) {
-		if (trial != null) {
+		if (trial != null && DataTable.isRowExpansionRequest(getResultListId())) {
 			if (!teamMemberCache.containsKey(trial.getId())) {
 				Collection teamMembers = null;
 				try {
@@ -147,7 +147,7 @@ public class TrialSearchBean extends SearchBeanBase {
 	}
 
 	public Collection<IDVO> getTimelineEvents(TrialOutVO trial) {
-		if (trial != null) {
+		if (trial != null && DataTable.isRowExpansionRequest(getResultListId())) {
 			if (!timelineEventCache.containsKey(trial.getId())) {
 				Collection timelineEvents = null;
 				try {
@@ -180,7 +180,7 @@ public class TrialSearchBean extends SearchBeanBase {
 	}
 
 	public Collection<IDVO> getTrialTagValues(TrialOutVO trial) {
-		if (trial != null) {
+		if (trial != null && DataTable.isRowExpansionRequest(getResultListId())) {
 			if (!trialTagValueCache.containsKey(trial.getId())) {
 				Collection trialTagValues = null;
 				try {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/ProbandListEntryBean.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/trial/ProbandListEntryBean.java
@@ -27,6 +27,7 @@ import org.phoenixctms.ctsms.vo.ProbandListStatusEntryOutVO;
 import org.phoenixctms.ctsms.vo.ProbandOutVO;
 import org.phoenixctms.ctsms.vo.ProbandStatusEntryOutVO;
 import org.phoenixctms.ctsms.vo.ProbandTagValueOutVO;
+import org.phoenixctms.ctsms.web.component.datatable.DataTable;
 import org.phoenixctms.ctsms.web.model.IDVO;
 import org.phoenixctms.ctsms.web.model.shared.ProbandListEntryBeanBase;
 import org.phoenixctms.ctsms.web.model.shared.ProbandListEntryModel;
@@ -224,7 +225,7 @@ public class ProbandListEntryBean extends ProbandListEntryBeanBase {
 	}
 
 	public Collection<IDVO> getProbandAddresses(ProbandOutVO proband) {
-		if (proband != null) {
+		if (proband != null && DataTable.isRowExpansionRequest(getDataTableId())) {
 			if (!probandAddressCache.containsKey(proband.getId())) {
 				Collection probandAddresses = null;
 				try {
@@ -247,7 +248,7 @@ public class ProbandListEntryBean extends ProbandListEntryBeanBase {
 	}
 
 	public Collection<IDVO> getProbandContactDetailValues(ProbandOutVO proband) {
-		if (proband != null) {
+		if (proband != null && DataTable.isRowExpansionRequest(getDataTableId())) {
 			if (!probandContactDetailValueCache.containsKey(proband.getId())) {
 				Collection probandContactDetailValues = null;
 				try {
@@ -283,7 +284,7 @@ public class ProbandListEntryBean extends ProbandListEntryBeanBase {
 	}
 
 	public Collection<IDVO> getProbandListStatus(ProbandOutVO proband) {
-		if (proband != null) {
+		if (proband != null && DataTable.isRowExpansionRequest(getDataTableId())) {
 			if (!probandListStatusCache.containsKey(proband.getId())) {
 				Collection<ProbandListStatusEntryOutVO> probandListStatus = null;
 				Collection probandListStatusFiltered = new ArrayList<ProbandListStatusEntryOutVO>();
@@ -321,7 +322,7 @@ public class ProbandListEntryBean extends ProbandListEntryBeanBase {
 	}
 
 	public Collection<IDVO> getProbandStatus(ProbandOutVO proband) {
-		if (proband != null) {
+		if (proband != null && DataTable.isRowExpansionRequest(getDataTableId())) {
 			if (!probandStatusCache.containsKey(proband.getId())) {
 				Collection probandStatus = null;
 				try {
@@ -344,7 +345,7 @@ public class ProbandListEntryBean extends ProbandListEntryBeanBase {
 	}
 
 	public Collection<IDVO> getProbandTagValues(ProbandOutVO proband) {
-		if (proband != null) {
+		if (proband != null && DataTable.isRowExpansionRequest(getDataTableId())) {
 			if (!probandTagValueCache.containsKey(proband.getId())) {
 				Collection probandTagValues = null;
 				try {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/util/WebUtil.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/util/WebUtil.java
@@ -2907,7 +2907,7 @@ public final class WebUtil {
 		return null;
 	}
 
-	private static String getParamValue(FacesContext context, String paramName) {
+	public static String getParamValue(FacesContext context, String paramName) {
 		if (context != null && paramName != null && paramName.length() > 0) {
 			return context.getExternalContext().getRequestParameterMap().get(paramName);
 		}

--- a/web/src/main/webapp/META-INF/includes/shared/trialSearcher.xhtml
+++ b/web/src/main/webapp/META-INF/includes/shared/trialSearcher.xhtml
@@ -211,6 +211,7 @@
 					sortBy="#{trial.vo.dutySelfAllocationLockedUntil}"
 					filterBy="#{trial.vo.dutySelfAllocationLocked}"
 					filterOptions="#{sessionScopeBean.filterBooleans}">
+					<f:attribute name="visibleDefault" value = "false" />
 					<f:facet name="header">
 						<h:outputText value="#{triallabels.search_trial_result_list_duty_self_allocation_locked_column}" />
 					</f:facet>

--- a/web/src/main/webapp/META-INF/templates/baseTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/baseTemplate.xhtml
@@ -335,7 +335,7 @@
 		<ui:param name="dataTablesScrollableFullPageTab" value="false" />
 		<ui:param name="dataTablesScrollHeightFullPageTab" value="" />
 		<ui:param name="dataTablesResizableColumnsFullPageTab" value="false" />
-		<ui:param name="dataTablesRowsSearch" value="5" />
+		<ui:param name="dataTablesRowsSearch" value="10" />
 		<ui:param name="dataTablesPaginatorSearch" value="true" />
 		<ui:param name="dataTablesPaginatorTemplateSearch"
 			value="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}" />

--- a/web/src/main/webapp/META-INF/templates/baseTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/baseTemplate.xhtml
@@ -335,7 +335,7 @@
 		<ui:param name="dataTablesScrollableFullPageTab" value="false" />
 		<ui:param name="dataTablesScrollHeightFullPageTab" value="" />
 		<ui:param name="dataTablesResizableColumnsFullPageTab" value="false" />
-		<ui:param name="dataTablesRowsSearch" value="20" />
+		<ui:param name="dataTablesRowsSearch" value="5" />
 		<ui:param name="dataTablesPaginatorSearch" value="true" />
 		<ui:param name="dataTablesPaginatorTemplateSearch"
 			value="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}" />


### PR DESCRIPTION
With the latest new feature (parent user hierarchy https://github.com/phoenixctms/ctsms/pull/177 ) particular DTO graphs tend to take a bit more time to compute. It manifests subtle eg. with the loading times of the (queryeditor) search result lists.

Profiling shows the rowsexpansion areas of eg. a row of trial search results shows increased time. It will be adressed by

- load rowexpansion data only when there actaully *are* expanded rowexpansion areas
- the default page size is reduced to show (load) overall less records initially
