### PR TITLE
log4j CVE-2019-17571

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -137,10 +137,16 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
+		<!-- <dependency>
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
+		</dependency> -->
+		
+		<dependency>
+		 	<groupId>ch.qos.reload4j</groupId>
+			<artifactId>reload4j</artifactId>
 		</dependency>
+		
 		<dependency>
 			<groupId>org.testng</groupId>
 			<artifactId>testng</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -297,11 +297,18 @@
 				<version>4.13.1</version>
 				<scope>test</scope>
 			</dependency>
-			 <dependency>
+			<!-- <dependency>
 				<groupId>log4j</groupId>
 				<artifactId>log4j</artifactId>
 				<version>1.2.17</version>
-			</dependency> 
+			</dependency>  -->
+			
+			<dependency>
+			  <groupId>ch.qos.reload4j</groupId>
+			  <artifactId>reload4j</artifactId>
+			  <version>1.2.19</version>
+			</dependency>
+			
 			<dependency>
 				<groupId>org.apache.xmlbeans</groupId>
 				<artifactId>xmlbeans</artifactId>


### PR DESCRIPTION
the vulnerable JMSAppender or SocketServer of log4j 1.2.x are not used in Phoenix,
however switching now to "reload4j" to silence related dependabot alerts.