### PR TITLE
use left join in getLog() finders when no ecrfId is provided

### DIFF
--- a/core/src/main/java/org/phoenixctms/ctsms/domain/ECRFFieldStatusEntryDaoImpl.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/domain/ECRFFieldStatusEntryDaoImpl.java
@@ -153,7 +153,7 @@ public class ECRFFieldStatusEntryDaoImpl
 		DetachedCriteria subQuery = createEcrfFieldStatusEntryDetachedCriteria(ecrfFieldStatusEntryCriteria, probandListEntryCriteria, ecrfFieldCriteria, queue, probandListEntryId,
 				ecrfFieldId);
 		if (visitCriteria == null) {
-			visitCriteria = ecrfFieldStatusEntryCriteria.createCriteria("visit", "visit0");
+			visitCriteria = ecrfFieldStatusEntryCriteria.createCriteria("visit", "visit0", CriteriaSpecification.LEFT_JOIN);
 		}
 		subQuery.add(Restrictions.or(Restrictions.and(Restrictions.isNull("visit.id"), Restrictions.isNull(visitCriteria.getAlias() + ".id")),
 				Restrictions.eqProperty("visit.id", visitCriteria.getAlias() + ".id")));
@@ -747,7 +747,7 @@ public class ECRFFieldStatusEntryDaoImpl
 			if (last) {
 				// uncorrelated - fast:
 				// value with max id only:
-				visitCriteria = ecrfFieldStatusEntryCriteria.createCriteria("visit", "visit0");
+				visitCriteria = ecrfFieldStatusEntryCriteria.createCriteria("visit", "visit0", CriteriaSpecification.LEFT_JOIN);
 				applyEcrfFieldStatusEntryMaxIdSubCriteria(ecrfFieldStatusEntryCriteria, listEntryCriteria, visitCriteria, ecrfFieldCriteria, queue, probandListEntryId, null);
 			}
 		}
@@ -804,7 +804,7 @@ public class ECRFFieldStatusEntryDaoImpl
 			if (last) {
 				// uncorrelated - fast:
 				// value with max id only:
-				visitCriteria = ecrfFieldStatusEntryCriteria.createCriteria("visit", "visit0");
+				visitCriteria = ecrfFieldStatusEntryCriteria.createCriteria("visit", "visit0", CriteriaSpecification.LEFT_JOIN);
 				applyEcrfFieldStatusEntryMaxIdSubCriteria(ecrfFieldStatusEntryCriteria, listEntryCriteria, visitCriteria, ecrfFieldCriteria, queue, probandListEntryId, null);
 			}
 		}

--- a/core/src/main/java/org/phoenixctms/ctsms/domain/ECRFFieldValueDaoImpl.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/domain/ECRFFieldValueDaoImpl.java
@@ -164,7 +164,7 @@ public class ECRFFieldValueDaoImpl
 			Long probandListEntryId, Long ecrfFieldId) {
 		DetachedCriteria subQuery = createEcrfFieldValueDetachedCriteria(ecrfFieldValueCriteria, probandListEntryCriteria, ecrfFieldCriteria, probandListEntryId, ecrfFieldId);
 		if (visitCriteria == null) {
-			visitCriteria = ecrfFieldValueCriteria.createCriteria("visit", "visit0");
+			visitCriteria = ecrfFieldValueCriteria.createCriteria("visit", "visit0", CriteriaSpecification.LEFT_JOIN);
 		}
 		subQuery.add(Restrictions.or(Restrictions.and(Restrictions.isNull("visit.id"), Restrictions.isNull(visitCriteria.getAlias() + ".id")),
 				Restrictions.eqProperty("visit.id", visitCriteria.getAlias() + ".id")));
@@ -761,7 +761,7 @@ public class ECRFFieldValueDaoImpl
 			}
 			subQuery = createEcrfFieldValueDetachedCriteria(ecrfFieldValueCriteria, listEntryCriteria, ecrfFieldCriteria, probandListEntryId, visitId, null);
 		} else {
-			visitCriteria = ecrfFieldValueCriteria.createCriteria("visit", "visit0");
+			visitCriteria = ecrfFieldValueCriteria.createCriteria("visit", "visit0", CriteriaSpecification.LEFT_JOIN);
 			subQuery = createEcrfFieldValueDetachedCriteria(ecrfFieldValueCriteria, listEntryCriteria, visitCriteria, ecrfFieldCriteria, probandListEntryId, null);
 		}
 		subQuery.setProjection(Projections.rowCount());
@@ -810,7 +810,7 @@ public class ECRFFieldValueDaoImpl
 			}
 			subQuery = createEcrfFieldValueDetachedCriteria(ecrfFieldValueCriteria, listEntryCriteria, ecrfFieldCriteria, probandListEntryId, visitId, null);
 		} else {
-			visitCriteria = ecrfFieldValueCriteria.createCriteria("visit", "visit0");
+			visitCriteria = ecrfFieldValueCriteria.createCriteria("visit", "visit0", CriteriaSpecification.LEFT_JOIN);
 			subQuery = createEcrfFieldValueDetachedCriteria(ecrfFieldValueCriteria, listEntryCriteria, visitCriteria, ecrfFieldCriteria, probandListEntryId, null);
 		}
 		subQuery.setProjection(Projections.rowCount());


### PR DESCRIPTION
this is a regression from 7fd549af6cb26943453a189a85ce58f65279fd95 "ecrf<->visits *many-to-many* - adjust DAOs"
that comes into effect in the uncommon case of using eCRFs without any visit.