### PR TITLE
search result paginator add pagesizes 100,200,500

### DIFF
--- a/web/src/main/webapp/META-INF/templates/baseTemplate.xhtml
+++ b/web/src/main/webapp/META-INF/templates/baseTemplate.xhtml
@@ -357,7 +357,7 @@
 		<ui:param name="dataTablesPaginatorTemplateSearch"
 			value="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}" />
 		<ui:param name="dataTablesRowsPerPageTemplateSearch"
-			value="5,10,20,50" />
+			value="5,10,20,50,100,200,500" />
 		<ui:param name="dataTablesPaginatorPositionSearch" value="both" />
 		<ui:param name="dataTablesPageLinksSearch" value="10" />
 		<ui:param name="dataTablesPaginatorAlwaysVisibleSearch" value="true" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Expanded rows-per-page options in the Search results table, allowing users to view more results per page with new choices (100, 200, 500) in addition to existing (5, 10, 20, 50). Improves flexibility for power users and reduces paging when scanning large result sets.
  * Existing options remain available. No other behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->