### PR TITLE
strikethrough items marked for deletion in datagrids

### DIFF
--- a/web/src/main/webapp/META-INF/includes/course/adminCourseParticipationStatus.xhtml
+++ b/web/src/main/webapp/META-INF/includes/course/adminCourseParticipationStatus.xhtml
@@ -370,6 +370,7 @@
 								</p:column>
 								<p:column>
 									<h:outputText
+									    styleClass="#{staff.vo.deferredDelete ? 'ctsms-strikethrough' : ''}"
 										value="#{applicationScopeBean.escapeHtml(staff.vo.name)}"
 										escape="false" />
 								</p:column>

--- a/web/src/main/webapp/META-INF/includes/course/courseMain.xhtml
+++ b/web/src/main/webapp/META-INF/includes/course/courseMain.xhtml
@@ -523,6 +523,7 @@
 										</p:column>
 										<p:column>
 											<h:outputText
+											    styleClass="#{course.vo.deferredDelete ? 'ctsms-strikethrough' : ''}"
 												value="#{applicationScopeBean.escapeHtml(course.vo.name)}"
 												escape="false" />
 										</p:column>

--- a/web/src/main/webapp/META-INF/includes/massmail/massMailRecipient.xhtml
+++ b/web/src/main/webapp/META-INF/includes/massmail/massMailRecipient.xhtml
@@ -200,6 +200,7 @@
 								</p:column>
 								<p:column>
 									<h:outputText
+									    styleClass="#{proband.vo.deferredDelete ? 'ctsms-strikethrough' : ''}"
 										value="#{applicationScopeBean.escapeHtml(proband.vo.name)}"
 										escape="false" />
 								</p:column>

--- a/web/src/main/webapp/META-INF/includes/proband/probandMain.xhtml
+++ b/web/src/main/webapp/META-INF/includes/proband/probandMain.xhtml
@@ -832,6 +832,7 @@
 									</p:column>
 									<p:column>
 										<h:outputText
+										    styleClass="#{proband.vo.deferredDelete ? 'ctsms-strikethrough' : ''}"
 											value="#{applicationScopeBean.escapeHtml(proband.vo.name)}"
 											escape="false" />
 									</p:column>

--- a/web/src/main/webapp/META-INF/includes/shared/duplicatesDialog.xhtml
+++ b/web/src/main/webapp/META-INF/includes/shared/duplicatesDialog.xhtml
@@ -50,6 +50,7 @@
 
 						<h:outputText value=" " />
 						<h:outputText
+						    styleClass="#{duplicate.vo.deferredDelete ? 'ctsms-strikethrough' : ''}"
 							value="#{applicationScopeBean.escapeHtml(duplicate.vo.name)}"
 							escape="false" />
 						<h:outputText rendered="#{not empty duplicate.vo.dateOfBirth}" value=" " />

--- a/web/src/main/webapp/META-INF/includes/trial/ecrfField.xhtml
+++ b/web/src/main/webapp/META-INF/includes/trial/ecrfField.xhtml
@@ -381,6 +381,7 @@
 									</p:column>
 									<p:column>
 										<h:outputText
+										    styleClass="#{inputField.vo.deferredDelete ? 'ctsms-strikethrough' : ''}"
 											value="#{applicationScopeBean.escapeHtml(inputField.vo.name)}"
 											escape="false" />
 									</p:column>

--- a/web/src/main/webapp/META-INF/includes/trial/inquiry.xhtml
+++ b/web/src/main/webapp/META-INF/includes/trial/inquiry.xhtml
@@ -301,6 +301,7 @@
 								</p:column>
 								<p:column>
 									<h:outputText
+									    styleClass="#{inputField.vo.deferredDelete ? 'ctsms-strikethrough' : ''}"
 										value="#{applicationScopeBean.escapeHtml(inputField.vo.name)}"
 										escape="false" />
 								</p:column>

--- a/web/src/main/webapp/META-INF/includes/trial/probandList.xhtml
+++ b/web/src/main/webapp/META-INF/includes/trial/probandList.xhtml
@@ -476,6 +476,7 @@
 								</p:column>
 								<p:column>
 									<h:outputText
+									    styleClass="#{proband.vo.deferredDelete ? 'ctsms-strikethrough' : ''}"
 										value="#{applicationScopeBean.escapeHtml(proband.vo.name)}"
 										escape="false" />
 								</p:column>

--- a/web/src/main/webapp/META-INF/includes/trial/probandListEntryTag.xhtml
+++ b/web/src/main/webapp/META-INF/includes/trial/probandListEntryTag.xhtml
@@ -304,6 +304,7 @@
 								</p:column>
 								<p:column>
 									<h:outputText
+									    styleClass="#{inputField.vo.deferredDelete ? 'ctsms-strikethrough' : ''}"
 										value="#{applicationScopeBean.escapeHtml(inputField.vo.name)}"
 										escape="false" />
 								</p:column>

--- a/web/src/main/webapp/META-INF/includes/trial/teamMember.xhtml
+++ b/web/src/main/webapp/META-INF/includes/trial/teamMember.xhtml
@@ -216,6 +216,7 @@
 								</p:column>
 								<p:column>
 									<h:outputText
+									    styleClass="#{staff.vo.deferredDelete ? 'ctsms-strikethrough' : ''}"
 										value="#{applicationScopeBean.escapeHtml(staff.vo.name)}"
 										escape="false" />
 								</p:column>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated UI components across courses, staff, probands, trials, and related sections to consistently display strikethrough styling for items marked for deferred deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->