### PR TITLE
per-cell background color in Excel spreadsheets

### DIFF
--- a/core/src/main/java/org/phoenixctms/ctsms/excel/AuditTrailExcelWriter.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/excel/AuditTrailExcelWriter.java
@@ -484,7 +484,7 @@ public class AuditTrailExcelWriter extends WorkbookWriter {
 	}
 
 	@Override
-	public Color voToColor(Object vo) {
+	public Color voToRowColor(Object vo) {
 		if (vo instanceof ECRFFieldStatusEntryOutVO) {
 			return ((ECRFFieldStatusEntryOutVO) vo).getStatus().getColor();
 		}

--- a/core/src/main/java/org/phoenixctms/ctsms/excel/ExcelUtil.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/excel/ExcelUtil.java
@@ -58,22 +58,25 @@ public final class ExcelUtil {
 	private final static HashMap<Color, Colour> COLOR_MAPPING = new HashMap<Color, Colour>();
 	static {
 		// http://jexcelapi.sourceforge.net/resources/javadocs/2_6_10/docs/jxl/format/Colour.html
+		// lighter JXL palette entries than the web/css colours for softer excel backgrounds
 		COLOR_MAPPING.put(Color.LIGHTYELLOW, Colour.IVORY);
+		COLOR_MAPPING.put(Color.YELLOW, Colour.VERY_LIGHT_YELLOW);
 		COLOR_MAPPING.put(Color.ORANGE, Colour.LIGHT_ORANGE);
-		COLOR_MAPPING.put(Color.DARKORANGE, Colour.ORANGE);
+		COLOR_MAPPING.put(Color.DARKORANGE, Colour.LIGHT_ORANGE);
 		COLOR_MAPPING.put(Color.SPRINGGREEN, Colour.LIGHT_GREEN);
-		COLOR_MAPPING.put(Color.LIMEGREEN, Colour.BRIGHT_GREEN);
-		COLOR_MAPPING.put(Color.LIME, Colour.LIME);
+		COLOR_MAPPING.put(Color.LIMEGREEN, Colour.LIGHT_GREEN);
+		COLOR_MAPPING.put(Color.LIME, Colour.LIGHT_GREEN);
 		COLOR_MAPPING.put(Color.TOMATO, Colour.CORAL);
 		COLOR_MAPPING.put(Color.MEDIUMSEAGREEN, Colour.SEA_GREEN);
-		COLOR_MAPPING.put(Color.RED, Colour.RED);
+		COLOR_MAPPING.put(Color.RED, Colour.ROSE);
 		COLOR_MAPPING.put(Color.ORANGERED, Colour.TAN);
+		COLOR_MAPPING.put(Color.CYAN, Colour.LIGHT_TURQUOISE);
 		COLOR_MAPPING.put(Color.LIGHTGRAY, Colour.GREY_25_PERCENT);
-		COLOR_MAPPING.put(Color.GREEN, Colour.GREEN);
+		COLOR_MAPPING.put(Color.GREEN, Colour.LIGHT_GREEN);
 		COLOR_MAPPING.put(Color.GAINSBORO, Colour.GREY_50_PERCENT);
 		COLOR_MAPPING.put(Color.SALMON, Colour.CORAL);
 		COLOR_MAPPING.put(Color.LIGHTSKYBLUE, Colour.SKY_BLUE);
-		COLOR_MAPPING.put(Color.OLIVE, Colour.DARK_YELLOW);
+		COLOR_MAPPING.put(Color.OLIVE, Colour.GOLD);
 		COLOR_MAPPING.put(Color.YELLOWGREEN, Colour.GOLD);
 		COLOR_MAPPING.put(Color.KHAKI, Colour.VERY_LIGHT_YELLOW);
 		COLOR_MAPPING.put(Color.ORCHID, Colour.ROSE);

--- a/core/src/main/java/org/phoenixctms/ctsms/excel/ExcelWriter.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/excel/ExcelWriter.java
@@ -15,7 +15,9 @@ public interface ExcelWriter {
 
 	public void init() throws Exception;
 
-	public Color voToColor(Object vo);
+	public Color voToRowColor(Object vo);
+
+	public Color voToCellColor(Object vo, String columnName);
 
 	public void writeSpreadSheets(WritableWorkbook workbook) throws Exception;
 }

--- a/core/src/main/java/org/phoenixctms/ctsms/excel/InventoryBookingsExcelWriter.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/excel/InventoryBookingsExcelWriter.java
@@ -301,7 +301,7 @@ public class InventoryBookingsExcelWriter extends WorkbookWriter {
 	}
 
 	@Override
-	public Color voToColor(Object vo) {
+	public Color voToRowColor(Object vo) {
 		return null;
 	}
 }

--- a/core/src/main/java/org/phoenixctms/ctsms/excel/JournalExcelWriter.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/excel/JournalExcelWriter.java
@@ -631,7 +631,7 @@ public class JournalExcelWriter extends WorkbookWriter {
 	}
 
 	@Override
-	public Color voToColor(Object vo) {
+	public Color voToRowColor(Object vo) {
 		return null;
 	}
 }

--- a/core/src/main/java/org/phoenixctms/ctsms/excel/ProbandListExcelWriter.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/excel/ProbandListExcelWriter.java
@@ -3,9 +3,14 @@ package org.phoenixctms.ctsms.excel;
 import java.io.File;
 import java.security.MessageDigest;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 
+import org.phoenixctms.ctsms.domain.ProbandListStatusEntry;
+import org.phoenixctms.ctsms.domain.ProbandListStatusEntryDao;
 import org.phoenixctms.ctsms.enumeration.Color;
 import org.phoenixctms.ctsms.enumeration.ProbandListStatusLogLevel;
 import org.phoenixctms.ctsms.enumeration.VariablePeriod;
@@ -144,6 +149,7 @@ public class ProbandListExcelWriter extends WorkbookWriter {
 	protected ProbandListExcelVO excelVO;
 	protected ProbandListStatusLogLevel logLevel;
 	protected TrialOutVO trial;
+	protected HashMap<Long, HashMap<String, Color>> distinctFieldRowCellColors;
 	protected static final String PROBAND_LIST_EXCEL_FILENAME_PREFIX = "proband_list_";
 
 	public static String getICAgeColumnName() {
@@ -193,6 +199,22 @@ public class ProbandListExcelWriter extends WorkbookWriter {
 				(visitScheduleItem != null && visitScheduleItem.getGroup() != null) ? visitScheduleItem.getGroup().getToken() : null,
 				(visitScheduleItem != null && visitScheduleItem.getVisit() != null) ? visitScheduleItem.getVisit().getToken() : null,
 				visitScheduleItem == null ? null : visitScheduleItem.getToken());
+	}
+
+	public static Color getVisitScheduleAppointmentRecentStatusColor(ProbandListStatusEntryDao probandListStatusEntryDao, Long trialId, Long probandId,
+			Long visitScheduleItemId, Date timestamp) {
+		if (probandListStatusEntryDao == null || trialId == null || probandId == null || visitScheduleItemId == null || timestamp == null) {
+			return null;
+		}
+		ProbandListStatusEntry probandListStatusEntry = probandListStatusEntryDao.findRecentStatus(trialId, probandId,
+				new HashSet<Long>(Arrays.asList(visitScheduleItemId)), CommonUtil.dateToTimestamp(timestamp));
+		if (probandListStatusEntry == null) {
+			probandListStatusEntry = probandListStatusEntryDao.findRecentStatus(trialId, probandId, new HashSet<Long>(), CommonUtil.dateToTimestamp(timestamp));
+		}
+		if (probandListStatusEntry != null) {
+			return probandListStatusEntry.getStatus().getColor();
+		}
+		return null;
 	}
 
 	protected ProbandListExcelWriter() {
@@ -571,6 +593,10 @@ public class ProbandListExcelWriter extends WorkbookWriter {
 		getSpreadSheetWriters().get(0).setDistinctFieldRows(distinctFieldRows);
 	}
 
+	public void setDistinctFieldRowCellColors(HashMap<Long, HashMap<String, Color>> distinctFieldRowCellColors) {
+		this.distinctFieldRowCellColors = distinctFieldRowCellColors;
+	}
+
 	@Override
 	public void setSpreadSheetName(String spreadSheetName) {
 		if (CommonUtil.isEmptyString(spreadSheetName)) {
@@ -647,11 +673,25 @@ public class ProbandListExcelWriter extends WorkbookWriter {
 	}
 
 	@Override
-	public Color voToColor(Object vo) {
+	public Color voToRowColor(Object vo) {
 		if (vo instanceof ProbandListEntryOutVO) {
 			ProbandListStatusEntryOutVO lastStatus = ((ProbandListEntryOutVO) vo).getLastStatus();
 			if (lastStatus != null) {
 				return lastStatus.getStatus().getColor();
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public Color voToCellColor(Object vo, String columnName) {
+		if (distinctFieldRowCellColors != null) {
+			Long id = CommonUtil.getVOId(vo);
+			if (id != null) {
+				HashMap<String, Color> fieldRowCellColors = distinctFieldRowCellColors.get(id);
+				if (fieldRowCellColors != null && fieldRowCellColors.containsKey(columnName)) {
+					return fieldRowCellColors.get(columnName);
+				}
 			}
 		}
 		return null;

--- a/core/src/main/java/org/phoenixctms/ctsms/excel/ReimbursementsExcelWriter.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/excel/ReimbursementsExcelWriter.java
@@ -474,7 +474,7 @@ public class ReimbursementsExcelWriter extends WorkbookWriter {
 	}
 
 	@Override
-	public Color voToColor(Object vo) {
+	public Color voToRowColor(Object vo) {
 		return null;
 	}
 }

--- a/core/src/main/java/org/phoenixctms/ctsms/excel/SearchResultExcelWriter.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/excel/SearchResultExcelWriter.java
@@ -527,7 +527,7 @@ public class SearchResultExcelWriter extends WorkbookWriter {
 	}
 
 	@Override
-	public Color voToColor(Object vo) {
+	public Color voToRowColor(Object vo) {
 		return null;
 	}
 }

--- a/core/src/main/java/org/phoenixctms/ctsms/excel/SpreadSheetWriter.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/excel/SpreadSheetWriter.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 
+import org.phoenixctms.ctsms.enumeration.Color;
 import org.phoenixctms.ctsms.util.CommonUtil;
 
 import jxl.CellView;
@@ -127,7 +128,7 @@ public class SpreadSheetWriter {
 	}
 
 	private void writeFieldRow(WritableSheet spreadSheet, HashMap<String, Object> fieldRow, int maxIndexedColumnIndex, int r, ExcelCellFormat f,
-			HashMap<String, WritableCellFormat> cellFormats) throws Exception {
+			HashMap<String, WritableCellFormat> cellFormats, Object vo) throws Exception {
 		if (fieldRow != null && distinctColumnNames != null && distinctColumnNames.size() > 0) {
 			int c = maxIndexedColumnIndex;
 			for (int d = 0; d < distinctColumnNames.size(); d++) {
@@ -137,6 +138,13 @@ public class SpreadSheetWriter {
 				if (columnIndex == null) {
 					c++;
 					columnIndex = c;
+				}
+				if (rowColors) {
+					Color bgColor = workbookWriter.voToCellColor(vo, columnName);
+					if (bgColor == null) {
+						bgColor = workbookWriter.voToRowColor(vo);
+					}
+					f.setBgColor(bgColor);
 				}
 				if (fieldValue != null) {
 					ExcelUtil.writeCell(spreadSheet, getColIndex(columnIndex.intValue()), r, fieldValue.getClass(), fieldValue, f, cellFormats, false);
@@ -250,7 +258,7 @@ public class SpreadSheetWriter {
 					Integer columnIndex = getColumnIndex(voColumn.getColumnName());
 					if (columnIndex != null) {
 						if (rowColors) {
-							rowFormat.setBgColor(workbookWriter.voToColor(vo));
+							rowFormat.setBgColor(workbookWriter.voToRowColor(vo));
 						}
 						voColumn.writeCell(spreadSheet, getColIndex(columnIndex.intValue()), r, vo, rowFormat, cellFormats);
 					}
@@ -258,10 +266,7 @@ public class SpreadSheetWriter {
 				if (distinctFieldRows != null && distinctFieldRows.size() > 0) {
 					Long id = CommonUtil.getVOId(vo);
 					if (id != null && distinctFieldRows.containsKey(id)) {
-						if (rowColors) {
-							rowFormat.setBgColor(workbookWriter.voToColor(vo));
-						}
-						writeFieldRow(spreadSheet, distinctFieldRows.get(id), maxIndexedColumnIndex, r, rowFormat, cellFormats);
+						writeFieldRow(spreadSheet, distinctFieldRows.get(id), maxIndexedColumnIndex, r, rowFormat, cellFormats, vo);
 					}
 				}
 				r += 1;
@@ -288,10 +293,7 @@ public class SpreadSheetWriter {
 					r += increment;
 					rPage += increment;
 				}
-				if (rowColors) {
-					rowFormat.setBgColor(null);
-				}
-				writeFieldRow(spreadSheet, row, maxIndexedColumnIndex, r, rowFormat, cellFormats);
+				writeFieldRow(spreadSheet, row, maxIndexedColumnIndex, r, rowFormat, cellFormats, null);
 				r += 1;
 				rPage += 1;
 			}

--- a/core/src/main/java/org/phoenixctms/ctsms/excel/TeamMembersExcelWriter.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/excel/TeamMembersExcelWriter.java
@@ -219,7 +219,7 @@ public class TeamMembersExcelWriter extends WorkbookWriter {
 	}
 
 	@Override
-	public Color voToColor(Object vo) {
+	public Color voToRowColor(Object vo) {
 		return null;
 	}
 }

--- a/core/src/main/java/org/phoenixctms/ctsms/excel/VisitScheduleExcelWriter.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/excel/VisitScheduleExcelWriter.java
@@ -1023,7 +1023,7 @@ public class VisitScheduleExcelWriter extends WorkbookWriter {
 	}
 
 	@Override
-	public Color voToColor(Object vo) {
+	public Color voToRowColor(Object vo) {
 		if (vo instanceof VisitScheduleItemOutVO) {
 			VisitScheduleItemOutVO visitScheduleItem = (VisitScheduleItemOutVO) vo;
 			Object distinctVo = getDistinctFieldRows().get(visitScheduleItem.getId()).get(RECENT_PROBAND_LIST_STATUS_ENTRY);

--- a/core/src/main/java/org/phoenixctms/ctsms/excel/WorkbookWriter.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/excel/WorkbookWriter.java
@@ -9,6 +9,7 @@ import java.util.Iterator;
 
 import org.phoenixctms.ctsms.util.L10nUtil;
 import org.phoenixctms.ctsms.util.L10nUtil.Locales;
+import org.phoenixctms.ctsms.enumeration.Color;
 
 import jxl.WorkbookSettings;
 import jxl.write.WritableSheet;
@@ -86,6 +87,11 @@ public abstract class WorkbookWriter implements ExcelWriter, ExcelOutput {
 	protected abstract void updateExcelVO();
 
 	protected ArrayList<String> getGroupLabels(Object lastRow, Object row) {
+		return null;
+	}
+
+	@Override
+	public Color voToCellColor(Object vo, String columnName) {
 		return null;
 	}
 

--- a/core/src/main/java/org/phoenixctms/ctsms/service/trial/TrialServiceImpl.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/service/trial/TrialServiceImpl.java
@@ -80,6 +80,7 @@ import org.phoenixctms.ctsms.compare.VisitScheduleItemIntervalComparator;
 import org.phoenixctms.ctsms.compare.VisitScheduleItemOutVOComparator;
 import org.phoenixctms.ctsms.domain.*;
 import org.phoenixctms.ctsms.email.NotificationMessageTemplateParameters;
+import org.phoenixctms.ctsms.enumeration.Color;
 import org.phoenixctms.ctsms.enumeration.ECRFFieldStatusQueue;
 import org.phoenixctms.ctsms.enumeration.ECRFValidationStatus;
 import org.phoenixctms.ctsms.enumeration.InputFieldType;
@@ -5260,11 +5261,13 @@ public class TrialServiceImpl
 		ProbandContactDetailValueDao probandContactDetailValueDao = this.getProbandContactDetailValueDao();
 		ArrayList<ProbandListEntryOutVO> VOs = new ArrayList<ProbandListEntryOutVO>(probandListEntries.size());
 		HashMap<Long, HashMap<String, Object>> distinctFieldRows = new HashMap<Long, HashMap<String, Object>>(probandListEntries.size());
+		HashMap<Long, HashMap<String, Color>> distinctFieldRowCellColors = new HashMap<Long, HashMap<String, Color>>(probandListEntries.size());
 		Iterator<ProbandListEntry> probandListEntriesIt = probandListEntries.iterator();
 		while (probandListEntriesIt.hasNext()) {
 			ProbandListEntry probandListEntry = probandListEntriesIt.next();
 			ProbandListEntryOutVO probandListEntryVO = probandListEntryDao.toProbandListEntryOutVO(probandListEntry);
 			HashMap<String, Object> fieldRow = new HashMap<String, Object>(distinctColumnNames.size());
+			HashMap<String, Color> fieldRowCellColors = new HashMap<String, Color>();
 			String fieldKey;
 			Collection tagValues = showTags ? probandTagValueDao.findByProband(probandListEntryVO.getProband().getId(), null) : new ArrayList<ProbandTagValue>();
 			probandTagValueDao.toProbandTagValueOutVOCollection(tagValues);
@@ -5406,18 +5409,42 @@ public class TrialServiceImpl
 			visitScheduleItemsIt = visitScheduleItems.iterator();
 			while (visitScheduleItemsIt.hasNext()) {
 				VisitScheduleItemOutVO visitScheduleItemVO = visitScheduleItemsIt.next();
-				VisitScheduleItem visitScheduleAppointment = visitScheduleAppointmentMap.get(visitScheduleItemVO.getId());
+				VisitScheduleItem visitScheduleAppointment = visitScheduleAppointmentMap == null ? null : visitScheduleAppointmentMap.get(visitScheduleItemVO.getId());
+				Long listEntryTrialId = probandListEntryVO.getTrial().getId();
+				Long listEntryProbandId = probandListEntryVO.getProband().getId();
+				Long visitScheduleItemId = visitScheduleItemVO.getId();
 				if (showVisitScheduleAppointmentsStart) {
 					fieldKey = ProbandListExcelWriter.getVisitScheduleAppointmentsStartColumnName(visitScheduleItemVO);
-					fieldRow.put(fieldKey, visitScheduleAppointment.getStart());
+					if (visitScheduleAppointment != null) {
+						fieldRow.put(fieldKey, visitScheduleAppointment.getStart());
+						Color cellColor = ProbandListExcelWriter.getVisitScheduleAppointmentRecentStatusColor(probandListStatusEntryDao, listEntryTrialId, listEntryProbandId,
+								visitScheduleItemId, visitScheduleAppointment.getStart());
+						if (cellColor != null) {
+							fieldRowCellColors.put(fieldKey, cellColor);
+						}
+					}
 				}
 				if (showVisitScheduleAppointmentsStop) {
 					fieldKey = ProbandListExcelWriter.getVisitScheduleAppointmentsStopColumnName(visitScheduleItemVO);
-					fieldRow.put(fieldKey, visitScheduleAppointment.getStop());
+					if (visitScheduleAppointment != null) {
+						fieldRow.put(fieldKey, visitScheduleAppointment.getStop());
+						Color cellColor = ProbandListExcelWriter.getVisitScheduleAppointmentRecentStatusColor(probandListStatusEntryDao, listEntryTrialId, listEntryProbandId,
+								visitScheduleItemId, visitScheduleAppointment.getStop());
+						if (cellColor != null) {
+							fieldRowCellColors.put(fieldKey, cellColor);
+						}
+					}
 				}
 				if (showVisitScheduleAppointmentsStartStop) {
 					fieldKey = ProbandListExcelWriter.getVisitScheduleAppointmentsStartStopColumnName(visitScheduleItemVO);
 					fieldRow.put(fieldKey, ProbandListExcelWriter.getVisitScheduleAppointmentValue(visitScheduleItemDao.toVisitScheduleItemOutVO(visitScheduleAppointment)));
+					if (visitScheduleAppointment != null) {
+						Color cellColor = ProbandListExcelWriter.getVisitScheduleAppointmentRecentStatusColor(probandListStatusEntryDao, listEntryTrialId, listEntryProbandId,
+								visitScheduleItemId, visitScheduleAppointment.getStop());
+						if (cellColor != null) {
+							fieldRowCellColors.put(fieldKey, cellColor);
+						}
+					}
 				}
 			}
 			HashMap<Long, InquiryValue> inquiryValueMap;
@@ -5552,10 +5579,14 @@ public class TrialServiceImpl
 			}
 			VOs.add(probandListEntryVO);
 			distinctFieldRows.put(probandListEntryVO.getId(), fieldRow);
+			if (fieldRowCellColors.size() > 0) {
+				distinctFieldRowCellColors.put(probandListEntryVO.getId(), fieldRowCellColors);
+			}
 		}
 		writer.setVOs(VOs);
 		writer.setDistinctColumnNames(distinctColumnNames);
 		writer.setDistinctFieldRows(distinctFieldRows);
+		writer.setDistinctFieldRowCellColors(distinctFieldRowCellColors);
 		User user = CoreUtil.getUser();
 		writer.getExcelVO().setRequestingUser(this.getUserDao().toUserOutVO(user));
 		(new ExcelExporter(writer, writer)).write();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Excel exports now support distinct background colors for individual cells, including visit appointment status indicators.
  * Row and cell coloring is applied more consistently across spreadsheet exports.
  * Updated color mappings improve the appearance and readability of several status colors.

* **Bug Fixes**
  * Corrected status-based coloring in exported audit trails, visit schedules, and proband lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->