### PR TITLE
Allow self-transitions on terminal proband list status types

### DIFF
--- a/core/db/schema-set-version.sql
+++ b/core/db/schema-set-version.sql
@@ -11,4 +11,4 @@ begin
 end
 $$ language plpgsql;
 
-select set_database_version('010901008');
+select set_database_version('010901009');

--- a/core/db/schema-up-master.sql
+++ b/core/db/schema-up-master.sql
@@ -313,5 +313,60 @@ if get_database_version() < '010901008' then
 
 end if;
 
+if get_database_version() < '010901009' then
+
+  insert into PROBAND_LIST_STATUS_TRANSITION
+    ("proband_list_status_types_fk","transitions_fk")
+  values (
+    (select id from PROBAND_LIST_STATUS_TYPE where name_l10n_key = 'cancelled' limit 1),
+    (select id from PROBAND_LIST_STATUS_TYPE where name_l10n_key = 'cancelled' limit 1)
+  );
+
+  insert into PROBAND_LIST_STATUS_TRANSITION
+    ("proband_list_status_types_fk","transitions_fk")
+  values (
+    (select id from PROBAND_LIST_STATUS_TYPE where name_l10n_key = 'ic_not_signed' limit 1),
+    (select id from PROBAND_LIST_STATUS_TYPE where name_l10n_key = 'ic_not_signed' limit 1)
+  );
+
+  insert into PROBAND_LIST_STATUS_TRANSITION
+    ("proband_list_status_types_fk","transitions_fk")
+  values (
+    (select id from PROBAND_LIST_STATUS_TYPE where name_l10n_key = 'ic_not_signed_re_screening' limit 1),
+    (select id from PROBAND_LIST_STATUS_TYPE where name_l10n_key = 'ic_not_signed_re_screening' limit 1)
+  );
+
+  insert into PROBAND_LIST_STATUS_TRANSITION
+    ("proband_list_status_types_fk","transitions_fk")
+  values (
+    (select id from PROBAND_LIST_STATUS_TYPE where name_l10n_key = 'dropped_out' limit 1),
+    (select id from PROBAND_LIST_STATUS_TYPE where name_l10n_key = 'dropped_out' limit 1)
+  );
+
+  insert into PROBAND_LIST_STATUS_TRANSITION
+    ("proband_list_status_types_fk","transitions_fk")
+  values (
+    (select id from PROBAND_LIST_STATUS_TYPE where name_l10n_key = 'completed' limit 1),
+    (select id from PROBAND_LIST_STATUS_TYPE where name_l10n_key = 'completed' limit 1)
+  );
+
+  insert into PROBAND_LIST_STATUS_TRANSITION
+    ("proband_list_status_types_fk","transitions_fk")
+  values (
+    (select id from PROBAND_LIST_STATUS_TYPE where name_l10n_key = 'animal_dropped_out' limit 1),
+    (select id from PROBAND_LIST_STATUS_TYPE where name_l10n_key = 'animal_dropped_out' limit 1)
+  );
+
+  insert into PROBAND_LIST_STATUS_TRANSITION
+    ("proband_list_status_types_fk","transitions_fk")
+  values (
+    (select id from PROBAND_LIST_STATUS_TYPE where name_l10n_key = 'animal_completed' limit 1),
+    (select id from PROBAND_LIST_STATUS_TYPE where name_l10n_key = 'animal_completed' limit 1)
+  );
+
+  perform set_database_version('010901009');
+
+end if;
+
 end
 $$;

--- a/core/src/exec/java/org/phoenixctms/ctsms/executable/DemoDataProvider.java
+++ b/core/src/exec/java/org/phoenixctms/ctsms/executable/DemoDataProvider.java
@@ -2910,14 +2910,27 @@ public class DemoDataProvider {
 		ProbandListStatusTypeVO newState = null;
 		Collection<ProbandListStatusTypeVO> newStates = selectionSetService.getProbandListStatusTypeTransitions(auth, probandListEntry.getLastStatus().getStatus().getId());
 		if (newStates != null && newStates.size() > 0) {
-			HashSet<Long> newStateIds = new HashSet<Long>(newStates.size());
-			Iterator<ProbandListStatusTypeVO> it = newStates.iterator();
+			Long currentStatusId = probandListEntry.getLastStatus().getStatus().getId();
+			ArrayList<ProbandListStatusTypeVO> progressStates = new ArrayList<ProbandListStatusTypeVO>(newStates.size());
+			Iterator<ProbandListStatusTypeVO> progressIt = newStates.iterator();
+			while (progressIt.hasNext()) {
+				ProbandListStatusTypeVO state = progressIt.next();
+				if (!currentStatusId.equals(state.getId())) {
+					progressStates.add(state);
+				}
+			}
+			// Self-only transitions are terminal (same as an empty transition set).
+			if (progressStates.isEmpty()) {
+				return null;
+			}
+			HashSet<Long> newStateIds = new HashSet<Long>(progressStates.size());
+			Iterator<ProbandListStatusTypeVO> it = progressStates.iterator();
 			while (it.hasNext()) {
 				newStateIds.add(it.next().getId());
 			}
 			if (!allowPassed) {
 				while (newState == null) {
-					newState = random.getRandomElement(newStates);
+					newState = random.getRandomElement(progressStates);
 					newState = probandListStatusMarkov(newState, probandListStatusTypeMap);
 					if (!newStateIds.contains(newState.getId())) {
 						newState = null;
@@ -2927,7 +2940,7 @@ public class DemoDataProvider {
 				}
 			} else {
 				while (newState == null) {
-					newState = random.getRandomElement(newStates);
+					newState = random.getRandomElement(progressStates);
 					newState = probandListStatusMarkov(newState, probandListStatusTypeMap);
 					if (!newStateIds.contains(newState.getId())) {
 						newState = null;

--- a/core/src/exec/java/org/phoenixctms/ctsms/executable/ProductionDataProvider.java
+++ b/core/src/exec/java/org/phoenixctms/ctsms/executable/ProductionDataProvider.java
@@ -2125,12 +2125,12 @@ public class ProductionDataProvider {
 		updateProbandListStatusType(contactedProbandListStatusType,
 				getProbandListStatusTransitions(contactedProbandListStatusType, cancelledProbandListStatusType, acceptanceProbandListStatusType));
 		updateProbandListStatusType(cancelledProbandListStatusType,
-				getProbandListStatusTransitions());
+				getProbandListStatusTransitions(cancelledProbandListStatusType));
 		updateProbandListStatusType(acceptanceProbandListStatusType,
 				getProbandListStatusTransitions(contactedProbandListStatusType, acceptanceProbandListStatusType, icSignedProbandListStatusType, icNotSignedProbandListStatusType,
 						cancelledProbandListStatusType));
 		updateProbandListStatusType(icNotSignedProbandListStatusType,
-				getProbandListStatusTransitions());
+				getProbandListStatusTransitions(icNotSignedProbandListStatusType));
 		updateProbandListStatusType(
 				icSignedProbandListStatusType,
 				getProbandListStatusTransitions(icSignedProbandListStatusType, screeningOkProbandListStatusType, screeningFailureProbandListStatusType,
@@ -2152,7 +2152,7 @@ public class ProductionDataProvider {
 				getProbandListStatusTransitions(reScreeningProbandListStatusType, screeningOkProbandListStatusType, screeningFailureProbandListStatusType,
 						icSignedReScreeningProbandListStatusType, icNotSignedReScreeningProbandListStatusType));
 		updateProbandListStatusType(icNotSignedReScreeningProbandListStatusType,
-				getProbandListStatusTransitions());
+				getProbandListStatusTransitions(icNotSignedReScreeningProbandListStatusType));
 		updateProbandListStatusType(screeningFailureProbandListStatusType,
 				getProbandListStatusTransitions(reScreeningProbandListStatusType));
 		updateProbandListStatusType(ongoingProbandListStatusType,
@@ -2160,9 +2160,9 @@ public class ProductionDataProvider {
 		updateProbandListStatusType(ongoingRandomizedProbandListStatusType,
 				getProbandListStatusTransitions(ongoingRandomizedProbandListStatusType, ongoingProbandListStatusType, droppedOutProbandListStatusType, completedProbandListStatusType));
 		updateProbandListStatusType(droppedOutProbandListStatusType,
-				getProbandListStatusTransitions());
+				getProbandListStatusTransitions(droppedOutProbandListStatusType));
 		updateProbandListStatusType(completedProbandListStatusType,
-				getProbandListStatusTransitions());
+				getProbandListStatusTransitions(completedProbandListStatusType));
 		ProbandListStatusType animalUnderTestProbandListStatusType = createProbandListStatusType("animal_under_test", Color.LIGHTYELLOW,
 				true,
 				false,
@@ -2199,9 +2199,9 @@ public class ProductionDataProvider {
 		updateProbandListStatusType(animalUnderTestProbandListStatusType,
 				getProbandListStatusTransitions(animalUnderTestProbandListStatusType, animalDroppedOutProbandListStatusType, animalCompletedProbandListStatusType));
 		updateProbandListStatusType(animalDroppedOutProbandListStatusType,
-				getProbandListStatusTransitions());
+				getProbandListStatusTransitions(animalDroppedOutProbandListStatusType));
 		updateProbandListStatusType(animalCompletedProbandListStatusType,
-				getProbandListStatusTransitions());
+				getProbandListStatusTransitions(animalCompletedProbandListStatusType));
 		jobOutput.println("proband states created");
 	}
 

--- a/core/src/main/java/org/phoenixctms/ctsms/adapt/BlockingProbandListStatusCollisionFinder.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/adapt/BlockingProbandListStatusCollisionFinder.java
@@ -1,6 +1,7 @@
 package org.phoenixctms.ctsms.adapt;
 
 import java.sql.Timestamp;
+import java.util.Iterator;
 
 import org.phoenixctms.ctsms.domain.Proband;
 import org.phoenixctms.ctsms.domain.ProbandListStatusEntry;
@@ -18,6 +19,21 @@ public abstract class BlockingProbandListStatusCollisionFinder<IN, ENTITY> exten
 
 	protected abstract Trial getTrial(IN in) throws ServiceException;
 
+	/**
+	 * True if the status can leave itself (i.e. has at least one transition to a different status).
+	 * Self-only transitions are treated as terminal, same as an empty transition set.
+	 */
+	private static boolean hasOutgoingTransitions(ProbandListStatusType statusType) {
+		Iterator<ProbandListStatusType> it = statusType.getTransitions().iterator();
+		while (it.hasNext()) {
+			ProbandListStatusType transition = it.next();
+			if (transition != null && !statusType.getId().equals(transition.getId())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	@Override
 	protected boolean match(IN in,
 			ENTITY existing, Proband root) throws ServiceException {
@@ -28,7 +44,7 @@ public abstract class BlockingProbandListStatusCollisionFinder<IN, ENTITY> exten
 				return false;
 			} else {
 				ProbandListStatusType statusType = lastStatus.getStatus();
-				if (statusType.getTransitions().size() > 0) {
+				if (hasOutgoingTransitions(statusType)) {
 					return statusType.isBlocking();
 				} else if (statusType.isBlocking()) {
 					VariablePeriod blockingPeriod;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated status-transition handling for participant and animal records, allowing terminal statuses such as cancelled, completed, and dropped out to remain valid within transition workflows.
  - Ensured existing installations receive the updated transition configuration automatically during database upgrades.
  - Synchronized transition behavior across newly initialized and upgraded environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->