### PR TITLE
include dynamic visit schedule modes in recipient/reminder gates

### DIFF
--- a/core/src/main/java/org/phoenixctms/ctsms/service/massmail/MassMailServiceImpl.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/service/massmail/MassMailServiceImpl.java
@@ -876,7 +876,8 @@ public class MassMailServiceImpl
 						probandId = probandIdsIt.next();
 						ProbandListEntry listEntry = this.getProbandListEntryDao().findByTrialProband(visitScheduleItem.getTrial().getId(), probandId);
 						if (listEntry == null || (listEntry.getLastStatus() != null
-								&& !listEntry.getLastStatus().getStatus().isInitial())) {
+								&& !listEntry.getLastStatus().getStatus().isInitial())
+								|| ServiceUtil.VISIT_SCHEDULE_DATE_MODES_DYNAMIC.contains(visitScheduleItem.getMode())) {
 							//&& listEntry.getLastStatus().getStatus().getTransitions().size() > 0) {
 							this.getMassMailDao().lock(massMail, LockMode.PESSIMISTIC_WRITE);
 							MassMailRecipient recipient = massMailRecipientDao.findByMassMailProband(massMail.getId(), probandId);

--- a/core/src/main/java/org/phoenixctms/ctsms/service/shared/ToolsServiceImpl.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/service/shared/ToolsServiceImpl.java
@@ -1245,7 +1245,8 @@ public class ToolsServiceImpl
 				VisitScheduleItem visitScheduleItem = visitScheduleItemsIt.next();
 				ProbandListEntry listEntry = probandId != null ? this.getProbandListEntryDao().findByTrialProband(visitScheduleItem.getTrial().getId(), probandId) : null;
 				if (listEntry == null || (listEntry.getLastStatus() != null
-						&& !listEntry.getLastStatus().getStatus().isInitial())) {
+						&& !listEntry.getLastStatus().getStatus().isInitial())
+						|| ServiceUtil.VISIT_SCHEDULE_DATE_MODES_DYNAMIC.contains(visitScheduleItem.getMode())) {
 					//&& listEntry.getLastStatus().getStatus().getTransitions().size() > 0)) {
 					if (!ServiceUtil.testNotificationExists(visitScheduleItem.getNotifications(), org.phoenixctms.ctsms.enumeration.NotificationType.VISIT_SCHEDULE_ITEM_REMINDER,
 							false)) {

--- a/core/src/main/java/org/phoenixctms/ctsms/service/trial/TrialServiceImpl.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/service/trial/TrialServiceImpl.java
@@ -7894,8 +7894,9 @@ public class TrialServiceImpl
 								CommonUtil.dateToTimestamp(to))
 						: null;
 			}
-			if (lastStatus != null
-					&& !lastStatus.getStatus().isInitial()) {
+			if ((lastStatus != null
+					&& !lastStatus.getStatus().isInitial())
+					|| (proband != null && ServiceUtil.VISIT_SCHEDULE_DATE_MODES_DYNAMIC.contains(visitScheduleItem.getMode()))) {
 				// && lastStatus.getStatus().getTransitions().size() > 0) {
 				// for trial with many probands, display only contacted and not finished subjects:
 				VisitScheduleAppointmentVO visitScheduleItemProbandVO = visitScheduleItemDao.toVisitScheduleAppointmentVO(visitScheduleItem);

--- a/core/src/main/java/org/phoenixctms/ctsms/util/ServiceUtil.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/util/ServiceUtil.java
@@ -131,6 +131,8 @@ public final class ServiceUtil {
 	public final static String GROUP_VISIT_SPLIT_SEPARATOR = ";";
 	public final static String GROUP_VISIT_SPLIT_REGEX_PATTERN = Pattern.quote(GROUP_VISIT_SPLIT_SEPARATOR);
 	private final static Pattern GROUP_VISIT_BLOCK_SPLIT_REGEXP = Pattern.compile(GROUP_VISIT_SPLIT_REGEX_PATTERN);
+	public final static ArrayList<VisitScheduleDateMode> VISIT_SCHEDULE_DATE_MODES_DYNAMIC = new ArrayList<VisitScheduleDateMode>(
+			Arrays.asList(VisitScheduleDateMode.TAGS, VisitScheduleDateMode.TAG_DURATION));
 
 	public static void checkProbandGroupToken(String token) throws ServiceException {
 		if (GROUP_VISIT_BLOCK_SPLIT_REGEXP.matcher(token).find()) {


### PR DESCRIPTION
Allow TAGS and TAG_DURATION visit schedule items through the non-initial status checks for mass mail recipients, notifications, and appointments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved handling of dynamically scheduled visits.
  - Mass-mail recipient lists are now refreshed more consistently for visits using dynamic date modes.
  - Visit reminders are generated when appropriate for dynamically scheduled visits, including those with an initial status.
  - Appointment listings now include eligible dynamically scheduled visits, providing more complete scheduling information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->