### PR TITLE
add any_department RestApi search flag to skip department PSF filter

### DIFF
--- a/common/src/main/java/org/phoenixctms/ctsms/util/CommonUtil.java
+++ b/common/src/main/java/org/phoenixctms/ctsms/util/CommonUtil.java
@@ -289,6 +289,11 @@ public final class CommonUtil {
 	public static final String CONFIRM_PATH = "confirm";
 	public static final String API_REALM = "api";
 	public static final String EXEC_REALM = "exec";
+	/**
+	 * RestApi PSF filter / query param: when true, skips USER_/IDENTITY_DEPARTMENT_ID_FILTER injection
+	 * and is ignored by CriteriaUtil.apply*PSFVO (not a domain property).
+	 */
+	public static final String ANY_DEPARTMENT_FILTER_PARAM = "any_department";
 	private final static Pattern MESSAGE_FORMAT_PLACEHOLDER_REGEXP = Pattern.compile("(\\{\\d+\\})");
 	public static String SQL_LIKE_PERCENT_WILDCARD = "%";
 	public static String SQL_LIKE_UNDERSCORE_WILDCARD = "_";

--- a/core/src/main/java/org/phoenixctms/ctsms/intercept/AuthorisationInterceptor.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/intercept/AuthorisationInterceptor.java
@@ -134,6 +134,7 @@ public class AuthorisationInterceptor implements MethodBeforeAdvice {
 	 * Must match PSFUriPart.ANY_DEPARTMENT_QUERY_PARAM.
 	 */
 	public static final String ANY_DEPARTMENT_FILTER_PARAM = "any_department";
+	private static final ThreadLocal<Boolean> IGNORE_DEPARTMENT_ID_FILTER = new ThreadLocal<Boolean>();
 
 	private static Object getArgument(String parameterName, Map<String, Integer> argumentIndexMap, Object[] args) {
 		Integer index = argumentIndexMap.get(parameterName);
@@ -157,6 +158,23 @@ public class AuthorisationInterceptor implements MethodBeforeAdvice {
 		}
 		Object value = filters.remove(ANY_DEPARTMENT_FILTER_PARAM);
 		return Boolean.parseBoolean(value == null ? null : value.toString());
+	}
+
+	/** Strip any_department from every PSFVO arg; return true if any requested the bypass. */
+	private static boolean consumeAnyDepartmentFilterFromArgs(Object[] args) {
+		boolean ignore = false;
+		if (args != null) {
+			for (int i = 0; i < args.length; i++) {
+				if (consumeAnyDepartmentFilter(args[i])) {
+					ignore = true;
+				}
+			}
+		}
+		return ignore;
+	}
+
+	private static boolean ignoreDepartmentIdFilter() {
+		return Boolean.TRUE.equals(IGNORE_DEPARTMENT_ID_FILTER.get());
 	}
 
 	private static boolean getParameterValues(String parameterGetter, ArrayList<Object> parameterValues, Map<String, Integer> argIndexMap, Object[] args) throws Exception {
@@ -326,6 +344,16 @@ public class AuthorisationInterceptor implements MethodBeforeAdvice {
 	@Override
 	public void before(Method method, Object[] args, Object object) throws Throwable {
 		if (Settings.getBoolean(SettingCodes.ENABLE_AUTHORISATION, Bundle.SETTINGS, DefaultSettings.ENABLE_AUTHORISATION)) {
+			try {
+				IGNORE_DEPARTMENT_ID_FILTER.set(consumeAnyDepartmentFilterFromArgs(args));
+				beforeAuthorised(method, args, object);
+			} finally {
+				IGNORE_DEPARTMENT_ID_FILTER.remove();
+			}
+		}
+	}
+
+	private void beforeAuthorised(Method method, Object[] args, Object object) throws Throwable {
 			User user = CoreUtil.getUser();
 			if (user == null) {
 				throw L10nUtil.initAuthorisationException(AuthorisationExceptionCodes.NOT_AUTHENTICATED);
@@ -438,7 +466,7 @@ public class AuthorisationInterceptor implements MethodBeforeAdvice {
 									write = false;
 									break;
 								case USER_DEPARTMENT_ID_FILTER:
-									if (consumeAnyDepartmentFilter(getArgument(setter.getRootEntityName(), argIndexMap, args))) {
+									if (ignoreDepartmentIdFilter()) {
 										write = false;
 									} else {
 										write = true;
@@ -450,7 +478,7 @@ public class AuthorisationInterceptor implements MethodBeforeAdvice {
 									}
 									break;
 								case IDENTITY_DEPARTMENT_ID_FILTER:
-									if (consumeAnyDepartmentFilter(getArgument(setter.getRootEntityName(), argIndexMap, args))) {
+									if (ignoreDepartmentIdFilter()) {
 										write = false;
 									} else {
 										identity = user.getIdentity();
@@ -625,7 +653,6 @@ public class AuthorisationInterceptor implements MethodBeforeAdvice {
 					throw L10nUtil.initAuthorisationException(AuthorisationExceptionCodes.PARAMETER_DISJUNCTIVE_RESTRICTION_NOT_SATISFIED, (Object[]) serviceMethodNameParameter);
 				}
 			}
-		}
 	}
 
 	private static void checkHostIp(String ipRanges, String serviceMethod) throws Exception {

--- a/core/src/main/java/org/phoenixctms/ctsms/intercept/AuthorisationInterceptor.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/intercept/AuthorisationInterceptor.java
@@ -128,6 +128,12 @@ public class AuthorisationInterceptor implements MethodBeforeAdvice {
 	private static final String PARAMETER_GETTER_SETTER_SEPARATOR = ",";
 	private static final Pattern PARAMETER_GETTER_SETTER_SEPARATOR_REGEXP = Pattern.compile(" *" + Pattern.quote(PARAMETER_GETTER_SETTER_SEPARATOR) + " *");
 	private static final Pattern DEFAULT_DISJUNCTION_GROUP_SEPARATOR_REGEXP = Pattern.compile(" *: *");
+	/**
+	 * Reserved PSF filter / RestApi query param. When true, skips configured USER_/IDENTITY_DEPARTMENT_ID_FILTER
+	 * injection (intentional RestApi bypass for cross-department search use cases).
+	 * Must match PSFUriPart.ANY_DEPARTMENT_QUERY_PARAM.
+	 */
+	public static final String ANY_DEPARTMENT_FILTER_PARAM = "any_department";
 
 	private static Object getArgument(String parameterName, Map<String, Integer> argumentIndexMap, Object[] args) {
 		Integer index = argumentIndexMap.get(parameterName);
@@ -135,6 +141,22 @@ public class AuthorisationInterceptor implements MethodBeforeAdvice {
 			return args[index];
 		}
 		return null;
+	}
+
+	/**
+	 * Intentional RestApi bypass of configured department PSF filter overrides.
+	 * Consumes and removes {@link #ANY_DEPARTMENT_FILTER_PARAM} so it is never applied as a criteria property.
+	 */
+	private static boolean consumeAnyDepartmentFilter(Object psfArg) {
+		if (!(psfArg instanceof PSFVO)) {
+			return false;
+		}
+		Map filters = ((PSFVO) psfArg).getFilters();
+		if (filters == null || !filters.containsKey(ANY_DEPARTMENT_FILTER_PARAM)) {
+			return false;
+		}
+		Object value = filters.remove(ANY_DEPARTMENT_FILTER_PARAM);
+		return Boolean.parseBoolean(value == null ? null : value.toString());
 	}
 
 	private static boolean getParameterValues(String parameterGetter, ArrayList<Object> parameterValues, Map<String, Integer> argIndexMap, Object[] args) throws Exception {
@@ -416,24 +438,32 @@ public class AuthorisationInterceptor implements MethodBeforeAdvice {
 									write = false;
 									break;
 								case USER_DEPARTMENT_ID_FILTER:
-									write = true;
-									blankRootParameterValue = new PSFVO();
-									parameterValues = new Object[2];
-									parameterValues[0] = "department.id";
-									parameterValues[1] = Long.toString(user.getDepartment().getId());
-									invocationParameterValues.add(parameterValues);
+									if (consumeAnyDepartmentFilter(getArgument(setter.getRootEntityName(), argIndexMap, args))) {
+										write = false;
+									} else {
+										write = true;
+										blankRootParameterValue = new PSFVO();
+										parameterValues = new Object[2];
+										parameterValues[0] = "department.id";
+										parameterValues[1] = Long.toString(user.getDepartment().getId());
+										invocationParameterValues.add(parameterValues);
+									}
 									break;
 								case IDENTITY_DEPARTMENT_ID_FILTER:
-									identity = user.getIdentity();
-									if (identity == null) {
-										throw L10nUtil.initAuthorisationException(AuthorisationExceptionCodes.NO_IDENTITY);
+									if (consumeAnyDepartmentFilter(getArgument(setter.getRootEntityName(), argIndexMap, args))) {
+										write = false;
+									} else {
+										identity = user.getIdentity();
+										if (identity == null) {
+											throw L10nUtil.initAuthorisationException(AuthorisationExceptionCodes.NO_IDENTITY);
+										}
+										write = true;
+										blankRootParameterValue = new PSFVO();
+										parameterValues = new Object[2];
+										parameterValues[0] = "department.id";
+										parameterValues[1] = Long.toString(identity.getDepartment().getId());
+										invocationParameterValues.add(parameterValues);
 									}
-									write = true;
-									blankRootParameterValue = new PSFVO();
-									parameterValues = new Object[2];
-									parameterValues[0] = "department.id";
-									parameterValues[1] = Long.toString(identity.getDepartment().getId());
-									invocationParameterValues.add(parameterValues);
 									break;
 								case IDENTITY_TRIAL_TEAM_MEMBER_ID_FILTER:
 									identity = user.getIdentity();

--- a/core/src/main/java/org/phoenixctms/ctsms/intercept/AuthorisationInterceptor.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/intercept/AuthorisationInterceptor.java
@@ -128,13 +128,6 @@ public class AuthorisationInterceptor implements MethodBeforeAdvice {
 	private static final String PARAMETER_GETTER_SETTER_SEPARATOR = ",";
 	private static final Pattern PARAMETER_GETTER_SETTER_SEPARATOR_REGEXP = Pattern.compile(" *" + Pattern.quote(PARAMETER_GETTER_SETTER_SEPARATOR) + " *");
 	private static final Pattern DEFAULT_DISJUNCTION_GROUP_SEPARATOR_REGEXP = Pattern.compile(" *: *");
-	/**
-	 * Reserved PSF filter / RestApi query param. When true, skips configured USER_/IDENTITY_DEPARTMENT_ID_FILTER
-	 * injection (intentional RestApi bypass for cross-department search use cases).
-	 * Must match PSFUriPart.ANY_DEPARTMENT_QUERY_PARAM.
-	 */
-	public static final String ANY_DEPARTMENT_FILTER_PARAM = "any_department";
-	private static final ThreadLocal<Boolean> IGNORE_DEPARTMENT_ID_FILTER = new ThreadLocal<Boolean>();
 
 	private static Object getArgument(String parameterName, Map<String, Integer> argumentIndexMap, Object[] args) {
 		Integer index = argumentIndexMap.get(parameterName);
@@ -146,35 +139,32 @@ public class AuthorisationInterceptor implements MethodBeforeAdvice {
 
 	/**
 	 * Intentional RestApi bypass of configured department PSF filter overrides.
-	 * Consumes and removes {@link #ANY_DEPARTMENT_FILTER_PARAM} so it is never applied as a criteria property.
+	 * Reads {@link CommonUtil#ANY_DEPARTMENT_FILTER_PARAM} from psf.filters (does not remove; cleared after auth).
 	 */
-	private static boolean consumeAnyDepartmentFilter(Object psfArg) {
+	private static boolean isAnyDepartmentRequested(Object psfArg) {
 		if (!(psfArg instanceof PSFVO)) {
 			return false;
 		}
 		Map filters = ((PSFVO) psfArg).getFilters();
-		if (filters == null || !filters.containsKey(ANY_DEPARTMENT_FILTER_PARAM)) {
+		if (filters == null || !filters.containsKey(CommonUtil.ANY_DEPARTMENT_FILTER_PARAM)) {
 			return false;
 		}
-		Object value = filters.remove(ANY_DEPARTMENT_FILTER_PARAM);
+		Object value = filters.get(CommonUtil.ANY_DEPARTMENT_FILTER_PARAM);
 		return Boolean.parseBoolean(value == null ? null : value.toString());
 	}
 
-	/** Strip any_department from every PSFVO arg; return true if any requested the bypass. */
-	private static boolean consumeAnyDepartmentFilterFromArgs(Object[] args) {
-		boolean ignore = false;
-		if (args != null) {
-			for (int i = 0; i < args.length; i++) {
-				if (consumeAnyDepartmentFilter(args[i])) {
-					ignore = true;
+	private static void clearAnyDepartmentFilter(Object[] args) {
+		if (args == null) {
+			return;
+		}
+		for (int i = 0; i < args.length; i++) {
+			if (args[i] instanceof PSFVO) {
+				Map filters = ((PSFVO) args[i]).getFilters();
+				if (filters != null) {
+					filters.remove(CommonUtil.ANY_DEPARTMENT_FILTER_PARAM);
 				}
 			}
 		}
-		return ignore;
-	}
-
-	private static boolean ignoreDepartmentIdFilter() {
-		return Boolean.TRUE.equals(IGNORE_DEPARTMENT_ID_FILTER.get());
 	}
 
 	private static boolean getParameterValues(String parameterGetter, ArrayList<Object> parameterValues, Map<String, Integer> argIndexMap, Object[] args) throws Exception {
@@ -344,16 +334,6 @@ public class AuthorisationInterceptor implements MethodBeforeAdvice {
 	@Override
 	public void before(Method method, Object[] args, Object object) throws Throwable {
 		if (Settings.getBoolean(SettingCodes.ENABLE_AUTHORISATION, Bundle.SETTINGS, DefaultSettings.ENABLE_AUTHORISATION)) {
-			try {
-				IGNORE_DEPARTMENT_ID_FILTER.set(consumeAnyDepartmentFilterFromArgs(args));
-				beforeAuthorised(method, args, object);
-			} finally {
-				IGNORE_DEPARTMENT_ID_FILTER.remove();
-			}
-		}
-	}
-
-	private void beforeAuthorised(Method method, Object[] args, Object object) throws Throwable {
 			User user = CoreUtil.getUser();
 			if (user == null) {
 				throw L10nUtil.initAuthorisationException(AuthorisationExceptionCodes.NOT_AUTHENTICATED);
@@ -466,7 +446,7 @@ public class AuthorisationInterceptor implements MethodBeforeAdvice {
 									write = false;
 									break;
 								case USER_DEPARTMENT_ID_FILTER:
-									if (ignoreDepartmentIdFilter()) {
+									if (isAnyDepartmentRequested(getArgument(setter.getRootEntityName(), argIndexMap, args))) {
 										write = false;
 									} else {
 										write = true;
@@ -478,7 +458,7 @@ public class AuthorisationInterceptor implements MethodBeforeAdvice {
 									}
 									break;
 								case IDENTITY_DEPARTMENT_ID_FILTER:
-									if (ignoreDepartmentIdFilter()) {
+									if (isAnyDepartmentRequested(getArgument(setter.getRootEntityName(), argIndexMap, args))) {
 										write = false;
 									} else {
 										identity = user.getIdentity();
@@ -653,6 +633,8 @@ public class AuthorisationInterceptor implements MethodBeforeAdvice {
 					throw L10nUtil.initAuthorisationException(AuthorisationExceptionCodes.PARAMETER_DISJUNCTIVE_RESTRICTION_NOT_SATISFIED, (Object[]) serviceMethodNameParameter);
 				}
 			}
+			clearAnyDepartmentFilter(args);
+		}
 	}
 
 	private static void checkHostIp(String ipRanges, String serviceMethod) throws Exception {

--- a/core/src/main/java/org/phoenixctms/ctsms/query/CriteriaUtil.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/query/CriteriaUtil.java
@@ -722,8 +722,8 @@ public final class CriteriaUtil {
 					Iterator<Map.Entry<String, String>> filterIt = filters.entrySet().iterator();
 					while (filterIt.hasNext()) {
 						Map.Entry<String, String> filter = filterIt.next();
-						// Reserved RestApi flag (AuthorisationInterceptor.ANY_DEPARTMENT_FILTER_PARAM); never a domain property.
-						if ("any_department".equals(filter.getKey())) {
+						// Reserved RestApi flag (CommonUtil.ANY_DEPARTMENT_FILTER_PARAM); never a domain property.
+						if (CommonUtil.ANY_DEPARTMENT_FILTER_PARAM.equals(filter.getKey())) {
 							continue;
 						}
 						AssociationPath filterFieldAssociationPath = new AssociationPath(filter.getKey());
@@ -1186,8 +1186,8 @@ public final class CriteriaUtil {
 					Iterator<Map.Entry<String, String>> filterIt = filters.entrySet().iterator();
 					while (filterIt.hasNext()) {
 						Map.Entry<String, String> filter = filterIt.next();
-						// Reserved RestApi flag (AuthorisationInterceptor.ANY_DEPARTMENT_FILTER_PARAM); never a domain property.
-						if ("any_department".equals(filter.getKey())) {
+						// Reserved RestApi flag (CommonUtil.ANY_DEPARTMENT_FILTER_PARAM); never a domain property.
+						if (CommonUtil.ANY_DEPARTMENT_FILTER_PARAM.equals(filter.getKey())) {
 							continue;
 						}
 						AssociationPath filterFieldAssociationPath = new AssociationPath(filter.getKey());

--- a/core/src/main/java/org/phoenixctms/ctsms/query/CriteriaUtil.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/query/CriteriaUtil.java
@@ -722,6 +722,10 @@ public final class CriteriaUtil {
 					Iterator<Map.Entry<String, String>> filterIt = filters.entrySet().iterator();
 					while (filterIt.hasNext()) {
 						Map.Entry<String, String> filter = filterIt.next();
+						// Reserved RestApi flag (AuthorisationInterceptor.ANY_DEPARTMENT_FILTER_PARAM); never a domain property.
+						if ("any_department".equals(filter.getKey())) {
+							continue;
+						}
 						AssociationPath filterFieldAssociationPath = new AssociationPath(filter.getKey());
 						Criteria subCriteria;
 						if (distinct && sortJoin) {
@@ -1182,6 +1186,10 @@ public final class CriteriaUtil {
 					Iterator<Map.Entry<String, String>> filterIt = filters.entrySet().iterator();
 					while (filterIt.hasNext()) {
 						Map.Entry<String, String> filter = filterIt.next();
+						// Reserved RestApi flag (AuthorisationInterceptor.ANY_DEPARTMENT_FILTER_PARAM); never a domain property.
+						if ("any_department".equals(filter.getKey())) {
+							continue;
+						}
 						AssociationPath filterFieldAssociationPath = new AssociationPath(filter.getKey());
 						Criteria subCriteria;
 						if (sortFieldAssociationPath.isValid()

--- a/web/src/main/java/org/phoenixctms/ctsms/web/jersey/resource/PSFUriPart.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/jersey/resource/PSFUriPart.java
@@ -25,8 +25,8 @@ public class PSFUriPart extends PSFVO {
 	private static final String PAGE_NUMBER_QUERY_PARAM = "p";
 	private static final String PAGE_SIZE_QUERY_PARAM = "s";
 	private static final String UPDATE_ROW_COUNT_QUERY_PARAM = "c";
-	/** RestApi: when true, skips interceptor department.id PSF filter (AuthorisationInterceptor). */
-	public static final String ANY_DEPARTMENT_QUERY_PARAM = "any_department";
+	/** RestApi: when true, skips interceptor department.id PSF filter (see CommonUtil.ANY_DEPARTMENT_FILTER_PARAM). */
+	public static final String ANY_DEPARTMENT_QUERY_PARAM = CommonUtil.ANY_DEPARTMENT_FILTER_PARAM;
 	private boolean slurp;
 	private HashSet<String> slurpExcludes;
 	private final static LinkedHashSet<NamedParameter> NAMED_QUERY_PARAMETERS = new LinkedHashSet<NamedParameter>();

--- a/web/src/main/java/org/phoenixctms/ctsms/web/jersey/resource/PSFUriPart.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/jersey/resource/PSFUriPart.java
@@ -25,6 +25,8 @@ public class PSFUriPart extends PSFVO {
 	private static final String PAGE_NUMBER_QUERY_PARAM = "p";
 	private static final String PAGE_SIZE_QUERY_PARAM = "s";
 	private static final String UPDATE_ROW_COUNT_QUERY_PARAM = "c";
+	/** RestApi: when true, skips interceptor department.id PSF filter (AuthorisationInterceptor). */
+	public static final String ANY_DEPARTMENT_QUERY_PARAM = "any_department";
 	private boolean slurp;
 	private HashSet<String> slurpExcludes;
 	private final static LinkedHashSet<NamedParameter> NAMED_QUERY_PARAMETERS = new LinkedHashSet<NamedParameter>();
@@ -36,6 +38,7 @@ public class PSFUriPart extends PSFVO {
 		NAMED_QUERY_PARAMETERS.add(new NamedParameter(PAGE_SIZE_QUERY_PARAM, Integer.class));
 		NAMED_QUERY_PARAMETERS.add(new NamedParameter(UPDATE_ROW_COUNT_QUERY_PARAM, Boolean.TYPE));
 		NAMED_QUERY_PARAMETERS.add(new NamedParameter(GsonMessageBodyHandler.TIMEZONE_QUERY_PARAM, String.class));
+		NAMED_QUERY_PARAMETERS.add(new NamedParameter(ANY_DEPARTMENT_QUERY_PARAM, Boolean.TYPE));
 		SLURPED_QUERY_PARAMETERS.addAll(NAMED_QUERY_PARAMETERS);
 		SLURPED_QUERY_PARAMETERS.add(new NamedParameter("*", String.class));
 	}

--- a/web/src/main/webapp/resources/js/restApi.js
+++ b/web/src/main/webapp/resources/js/restApi.js
@@ -311,6 +311,10 @@ var RestApi = RestApi || {};
 			if (pageQuery.s != null) {
 				query.push('s=' + encodeURIComponent(pageQuery.s));
 			}
+			// Intentional RestApi bypass of USER_/IDENTITY_DEPARTMENT_ID_FILTER (AuthorisationInterceptor).
+			if (pageQuery.any_department === true || pageQuery.any_department === 'true') {
+				query.push('any_department=true');
+			}
 			if (query.length > 0) {
 				path += '?' + query.join('&');
 			}


### PR DESCRIPTION
Intentional bypass of USER_/IDENTITY_DEPARTMENT_ID_FILTER for cross-department RestApi searches (e.g. FieldCalculation duplicate checks).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `any_department` search option for retrieving results across departments when permitted.
  * REST API searches now recognize and transmit the cross-department search option.
  * The option is excluded from normal filter processing to prevent incorrect search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->