### PR TITLE
Show a centered loading spinner while dynamic TabView panels reload.

### DIFF
--- a/web/src/main/webapp/resources/css/default.css
+++ b/web/src/main/webapp/resources/css/default.css
@@ -472,6 +472,14 @@ td .ui-selectonemenu {
 	height: 100%;
 }
 
+.ctsms-tab-loading {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 8em;
+	padding: 1.5em;
+}
+
 .ctsms-probandlist-tabview {
 	width: 100%;
 	height: 100%;

--- a/web/src/main/webapp/resources/js/primefacesOverrides.js
+++ b/web/src/main/webapp/resources/js/primefacesOverrides.js
@@ -647,8 +647,9 @@ PrimeFaces.widget.TabView.prototype.loadDynamicTab = function(newPanel) {
             return;
         }
 
-        if(_self.cfg.onTabShow) {
-            _self.cfg.onTabShow.call(_self, newPanel);
+        // Use the callback captured for this request, and only if this panel is still active.
+        if (onTabShow && tabindex === _self.getActiveIndex()) {
+            onTabShow.call(_self, newPanel);
         }
     };
 

--- a/web/src/main/webapp/resources/js/primefacesOverrides.js
+++ b/web/src/main/webapp/resources/js/primefacesOverrides.js
@@ -581,7 +581,9 @@ PrimeFaces.widget.TabView.prototype.loadDynamicTab = function(newPanel) {
         update: this.id
     },
     tabindex = newPanel.index(),
-    onTabShow = this.cfg.onTabShow;
+    onTabShow = this.cfg.onTabShow,
+    // Keep previous nodes so a failed/aborted request can restore the pane.
+    previousContents = newPanel.contents().detach();
 
     newPanel.html(
         '<div class="ctsms-tab-loading">' +
@@ -594,6 +596,13 @@ PrimeFaces.widget.TabView.prototype.loadDynamicTab = function(newPanel) {
     this.show(newPanel);
     this.cfg.onTabShow = onTabShow;
 
+    function restorePreviousContents() {
+        if (previousContents) {
+            newPanel.empty().append(previousContents);
+            previousContents = null;
+        }
+    }
+
     options.onsuccess = function(responseXML) {
         var xmlDoc = $(responseXML.documentElement),
         updates = xmlDoc.find("update");
@@ -604,6 +613,7 @@ PrimeFaces.widget.TabView.prototype.loadDynamicTab = function(newPanel) {
             content = update.text();
 
             if(id == _self.id){
+                previousContents = null;
                 newPanel.html(content);
 
                 if(_self.cfg.cache) {
@@ -620,7 +630,23 @@ PrimeFaces.widget.TabView.prototype.loadDynamicTab = function(newPanel) {
         return true;
     };
 
-    options.oncomplete = function() {
+    options.onerror = function(status, errorThrown) {
+        restorePreviousContents();
+    };
+
+    options.oncomplete = function(xhr, status) {
+        if (status !== 'success') {
+            // Covers error/abort/timeout; onerror may already have restored.
+            restorePreviousContents();
+            return;
+        }
+
+        // Success without a panel update would leave the spinner; restore instead.
+        if (previousContents) {
+            restorePreviousContents();
+            return;
+        }
+
         if(_self.cfg.onTabShow) {
             _self.cfg.onTabShow.call(_self, newPanel);
         }

--- a/web/src/main/webapp/resources/js/primefacesOverrides.js
+++ b/web/src/main/webapp/resources/js/primefacesOverrides.js
@@ -571,6 +571,8 @@ PrimeFaces.widget.TabView.prototype.getTabTitle = function(index) {
 }
 
 //http://forum.primefaces.org/viewtopic.php?f=3&t=17987
+// Approach A: clear stale panel HTML and show a loading placeholder immediately,
+// but defer onTabShow until content is loaded (avoids changeXxx racing an empty panel).
 PrimeFaces.widget.TabView.prototype.loadDynamicTab = function(newPanel) {
     var _self = this,
     options = {
@@ -578,7 +580,19 @@ PrimeFaces.widget.TabView.prototype.loadDynamicTab = function(newPanel) {
         process: this.id + "_activeIndex",
         update: this.id
     },
-    tabindex = newPanel.index();
+    tabindex = newPanel.index(),
+    onTabShow = this.cfg.onTabShow;
+
+    newPanel.html(
+        '<div class="ctsms-tab-loading">' +
+            '<span class="ctsms-field-icon ctsms-icon-loading"></span>' +
+        '</div>'
+    );
+
+    // Show loading state now; suppress onTabShow until AJAX content is in place.
+    this.cfg.onTabShow = null;
+    this.show(newPanel);
+    this.cfg.onTabShow = onTabShow;
 
     options.onsuccess = function(responseXML) {
         var xmlDoc = $(responseXML.documentElement),
@@ -607,7 +621,9 @@ PrimeFaces.widget.TabView.prototype.loadDynamicTab = function(newPanel) {
     };
 
     options.oncomplete = function() {
-        _self.show(newPanel);
+        if(_self.cfg.onTabShow) {
+            _self.cfg.onTabShow.call(_self, newPanel);
+        }
     };
 
     options.params = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a centered loading state for tabs while content is being retrieved.
  * Tabs now display the loading indicator immediately during dynamic content loading.

* **Bug Fixes**
  * Improved tab behavior so configured tab actions run after content has finished loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->