### PR TITLE
Fix eCRF import hang from Closure JS minify during field checks.

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -96,12 +96,7 @@
 			<groupId>com.google.zxing</groupId>
 			<artifactId>core</artifactId>
 			<version>3.3.2</version>
-		</dependency>
-		<dependency>
-		    <groupId>com.google.javascript</groupId>
-		    <artifactId>closure-compiler</artifactId>
-		    <version>v20240317</version>
-	    </dependency>		
+		</dependency>		
 	</dependencies>
 	<build>
 		<!-- To change from default src/main/java and src/test/java - doesn't work 

--- a/common/src/main/java/org/phoenixctms/ctsms/util/JavaScriptCompressor.java
+++ b/common/src/main/java/org/phoenixctms/ctsms/util/JavaScriptCompressor.java
@@ -1,33 +1,318 @@
 package org.phoenixctms.ctsms.util;
+/*
+ * This file is part of the Echo Web Application Framework (hereinafter "Echo").
+ * Copyright (C) 2002-2009 NextApp, Inc.
+ *
+ * Version: MPL 1.1/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either the GNU General Public License Version 2 or later (the "GPL"), or the
+ * GNU Lesser General Public License Version 2.1 or later (the "LGPL"), in which
+ * case the provisions of the GPL or the LGPL are applicable instead of those
+ * above. If you wish to allow use of your version of this file only under the
+ * terms of either the GPL or the LGPL, and not to allow others to use your
+ * version of this file under the terms of the MPL, indicate your decision by
+ * deleting the provisions above and replace them with the notice and other
+ * provisions required by the GPL or the LGPL. If you do not delete the
+ * provisions above, a recipient may use your version of this file under the
+ * terms of any one of the MPL, the GPL or the LGPL.
+ */
 
-import com.google.javascript.jscomp.CompilationLevel;
-import com.google.javascript.jscomp.Compiler;
-import com.google.javascript.jscomp.CompilerOptions;
-import com.google.javascript.jscomp.SourceFile;
-
+/**
+ * Compresses a String containing JavaScript by removing comments and
+ * whitespace (Echo stripper).
+ * <p>
+ * History: Echo could infinite-loop on some inputs; Closure Compiler was used
+ * as a replacement but can block in JUL error reporting (import txn hang).
+ * Validation must use {@link #isEffectivelyEmpty(String)} — a bounded forward
+ * scan — not {@link #compress(String)}. {@code compress} remains for UI delivery
+ * and aborts via a step limit if the stripper misbehaves.
+ */
 public class JavaScriptCompressor {
 
-	public static String compress(String code) {
-		if (!CommonUtil.isEmptyString(code)) {
-			Compiler compiler = new Compiler();
-			CompilerOptions options = new CompilerOptions();
-			// SIMPLE_OPTIMIZATIONS is best for a direct replacement of your code.
-			// It removes comments and whitespace but keeps your variable names.
-			CompilationLevel.SIMPLE_OPTIMIZATIONS.setOptionsForCompilationLevel(options);
-			// Define the "file" name for error reporting purposes
-			options.setEmitUseStrict(false);
-			SourceFile extern = SourceFile.fromCode("externs.js", "");
-			SourceFile input = SourceFile.fromCode("input.js", code);
-			// Run the compiler
-			compiler.compile(extern, input, options);
-			if (compiler.hasErrors()) {
-				// Handle malformed JS here
-				//System.err.println("JS Error: " + compiler.getErrors()[0].description);
-				return code; // Or throw an exception
+	private static final char LINE_FEED = '\n';
+	private static final char CARRIAGE_RETURN = '\r';
+	private static final char SPACE = ' ';
+	private static final char TAB = '\t';
+
+	/**
+	 * True if {@code script} is null/blank or only whitespace and comments.
+	 * Single forward scan; {@code i} only increases — cannot hang.
+	 */
+	public static boolean isEffectivelyEmpty(String script) {
+		if (CommonUtil.isEmptyString(script)) {
+			return true;
+		}
+		int i = 0;
+		int n = script.length();
+		while (i < n) {
+			char c = script.charAt(i);
+			if (c == SPACE || c == TAB || c == LINE_FEED || c == CARRIAGE_RETURN) {
+				i++;
+				continue;
 			}
-			return compiler.toSource();
+			if (c == '/' && i + 1 < n) {
+				char next = script.charAt(i + 1);
+				if (next == '/') {
+					i += 2;
+					while (i < n) {
+						char x = script.charAt(i++);
+						if (x == LINE_FEED || x == CARRIAGE_RETURN) {
+							break;
+						}
+					}
+					continue;
+				}
+				if (next == '*') {
+					i += 2;
+					while (i + 1 < n && !(script.charAt(i) == '*' && script.charAt(i + 1) == '/')) {
+						i++;
+					}
+					if (i + 1 < n) {
+						i += 2;
+					} else {
+						return true; // unclosed block comment → no code
+					}
+					continue;
+				}
+			}
+			return false; // code, string, regex, division, …
+		}
+		return true;
+	}
+
+	/**
+	 * Compresses a String containing JavaScript by removing comments and
+	 * whitespace. For “has expression?” checks use {@link #isEffectivelyEmpty(String)}.
+	 *
+	 * @param script the String to compress
+	 * @return a compressed version
+	 */
+	public static String compress(String script) {
+		if (!CommonUtil.isEmptyString(script)) {
+			try {
+				JavaScriptCompressor jsc = new JavaScriptCompressor(script);
+				return jsc.outputBuffer.toString().trim(); //add trim to remove remaining newlines...
+			} catch (IllegalStateException e) {
+				// Pathological input: do not block callers; treat as non-empty original.
+				return script;
+			}
 		} else {
 			return "";
+		}
+	}
+
+	/** Original JavaScript text. */
+	private String script;
+	/**
+	 * Compressed output buffer.
+	 * This buffer may only be modified by invoking the <code>append()</code>
+	 * method.
+	 */
+	private StringBuffer outputBuffer;
+	/** Current parser cursor position in original text. */
+	private int pos;
+	/** Character at parser cursor position. */
+	private char ch;
+	/** Last character appended to buffer. */
+	private char lastAppend;
+	/** Flag indicating if end-of-buffer has been reached. */
+	private boolean endReached;
+	/** Flag indicating whether content has been appended after last identifier. */
+	private boolean contentAppendedAfterLastIdentifier = true;
+	/** Bounds scanning so comment/regex edge cases cannot spin forever. */
+	private int steps;
+	private final int maxSteps;
+
+	/**
+	 * Creates a new <code>JavaScriptCompressor</code> instance.
+	 *
+	 * @param script
+	 */
+	private JavaScriptCompressor(String script) {
+		this.script = script;
+		this.maxSteps = script.length() * 2 + 64;
+		outputBuffer = new StringBuffer(script.length());
+		nextChar();
+		while (!endReached) {
+			if (Character.isJavaIdentifierStart(ch)) {
+				renderIdentifier();
+			} else if (ch == ' ') {
+				skipWhiteSpace();
+			} else if (isWhitespace()) {
+				// Compress whitespace
+				skipWhiteSpace();
+			} else if ((ch == '"') || (ch == '\'')) {
+				// Handle strings
+				renderString();
+			} else if (ch == '/') {
+				// Handle comments
+				nextChar();
+				if (ch == '/') {
+					nextChar();
+					skipLineComment();
+				} else if (ch == '*') {
+					nextChar();
+					skipBlockComment();
+				} else {
+					append('/');
+				}
+			} else {
+				append(ch);
+				nextChar();
+			}
+		}
+	}
+
+	/**
+	 * Append character to output.
+	 *
+	 * @param ch the character to append
+	 */
+	private void append(char ch) {
+		lastAppend = ch;
+		outputBuffer.append(ch);
+		contentAppendedAfterLastIdentifier = true;
+	}
+
+	/**
+	 * Determines if current character is whitespace.
+	 *
+	 * @return true if the character is whitespace
+	 */
+	private boolean isWhitespace() {
+		return ch == CARRIAGE_RETURN || ch == SPACE || ch == TAB || ch == LINE_FEED;
+	}
+
+	/**
+	 * Load next character.
+	 */
+	private void nextChar() {
+		if (++steps > maxSteps) {
+			throw new IllegalStateException("JavaScriptCompressor step limit exceeded");
+		}
+		if (!endReached) {
+			if (pos < script.length()) {
+				ch = script.charAt(pos++);
+			} else {
+				endReached = true;
+				ch = 0;
+			}
+		}
+	}
+
+	/**
+	 * Adds an identifier to output.
+	 */
+	private void renderIdentifier() {
+		if (!contentAppendedAfterLastIdentifier)
+			append(SPACE);
+		append(ch);
+		nextChar();
+		while (Character.isJavaIdentifierPart(ch)) {
+			append(ch);
+			nextChar();
+		}
+		contentAppendedAfterLastIdentifier = false;
+	}
+
+	/**
+	 * Adds quoted String starting at current character to output.
+	 */
+	private void renderString() {
+		char startCh = ch; // Save quote char
+		append(ch);
+		nextChar();
+		while (true) {
+			if ((ch == LINE_FEED) || (ch == CARRIAGE_RETURN) || (endReached)) {
+				// JavaScript error: string not terminated
+				return;
+			} else {
+				if (ch == '\\') {
+					append(ch);
+					nextChar();
+					if ((ch == LINE_FEED) || (ch == CARRIAGE_RETURN) || (endReached)) {
+						// JavaScript error: string not terminated
+						return;
+					}
+					append(ch);
+					nextChar();
+				} else {
+					append(ch);
+					if (ch == startCh) {
+						nextChar();
+						return;
+					}
+					nextChar();
+				}
+			}
+		}
+	}
+
+	/**
+	 * Moves cursor past a line comment.
+	 */
+	private void skipLineComment() {
+		while ((ch != CARRIAGE_RETURN) && (ch != LINE_FEED)) {
+			if (endReached) {
+				return;
+			}
+			nextChar();
+		}
+	}
+
+	/**
+	 * Moves cursor past a block comment.
+	 */
+	private void skipBlockComment() {
+		while (true) {
+			if (endReached) {
+				return;
+			}
+			if (ch == '*') {
+				nextChar();
+				if (ch == '/') {
+					nextChar();
+					return;
+				}
+			} else
+				nextChar();
+		}
+	}
+
+	/**
+	 * Renders a new line character, provided previously rendered character
+	 * is not a newline.
+	 */
+	private void renderNewLine() {
+		if (lastAppend != '\n' && lastAppend != '\r') {
+			append('\n');
+		}
+	}
+
+	/**
+	 * Moves cursor past white space (including newlines).
+	 */
+	private void skipWhiteSpace() {
+		if (ch == LINE_FEED || ch == CARRIAGE_RETURN) {
+			renderNewLine();
+		} else {
+			append(ch);
+		}
+		nextChar();
+		while (ch == LINE_FEED || ch == CARRIAGE_RETURN || ch == SPACE || ch == TAB) {
+			if (ch == LINE_FEED || ch == CARRIAGE_RETURN) {
+				renderNewLine();
+			}
+			nextChar();
 		}
 	}
 }

--- a/common/src/main/java/org/phoenixctms/ctsms/util/JavaScriptCompressor.java
+++ b/common/src/main/java/org/phoenixctms/ctsms/util/JavaScriptCompressor.java
@@ -150,6 +150,9 @@ public class JavaScriptCompressor {
 			} else if (isWhitespace()) {
 				// Compress whitespace
 				skipWhiteSpace();
+			} else if (ch == '`') {
+				// ES6 template literals: preserve //, /* */, quotes, newlines until closing `
+				renderTemplateLiteral();
 			} else if ((ch == '"') || (ch == '\'')) {
 				// Handle strings
 				renderString();
@@ -254,6 +257,113 @@ public class JavaScriptCompressor {
 					nextChar();
 				}
 			}
+		}
+	}
+
+	/**
+	 * Emits an ES6 template literal intact (delimiters and contents), including
+	 * embedded newlines, quotes, and comment-like {@code //} / {@code /*} text.
+	 * Nested {@code ${...}} expressions are scanned with brace/string/template
+	 * awareness so the closing backtick is not missed.
+	 */
+	private void renderTemplateLiteral() {
+		append(ch); // opening `
+		nextChar();
+		while (!endReached) {
+			if (ch == '\\') {
+				append(ch);
+				nextChar();
+				if (endReached) {
+					return;
+				}
+				append(ch);
+				nextChar();
+				continue;
+			}
+			if (ch == '`') {
+				append(ch);
+				nextChar();
+				return;
+			}
+			if (ch == '$') {
+				append(ch);
+				nextChar();
+				if (ch == '{') {
+					append(ch);
+					nextChar();
+					renderTemplateExpression();
+				}
+				continue;
+			}
+			append(ch); // newlines, quotes, /*, //, etc.
+			nextChar();
+		}
+	}
+
+	/**
+	 * Emits a {@code ${...}} expression body until the matching {@code }},
+	 * respecting nested braces, strings, templates, and comments.
+	 */
+	private void renderTemplateExpression() {
+		int depth = 1;
+		while (!endReached && depth > 0) {
+			if (ch == '"' || ch == '\'') {
+				renderString();
+				continue;
+			}
+			if (ch == '`') {
+				renderTemplateLiteral();
+				continue;
+			}
+			if (ch == '/') {
+				nextChar();
+				if (ch == '/') {
+					append('/');
+					append('/');
+					nextChar();
+					while (!endReached && ch != LINE_FEED && ch != CARRIAGE_RETURN) {
+						append(ch);
+						nextChar();
+					}
+					continue;
+				}
+				if (ch == '*') {
+					append('/');
+					append('*');
+					nextChar();
+					while (!endReached) {
+						if (ch == '*') {
+							append(ch);
+							nextChar();
+							if (ch == '/') {
+								append(ch);
+								nextChar();
+								break;
+							}
+						} else {
+							append(ch);
+							nextChar();
+						}
+					}
+					continue;
+				}
+				append('/');
+				continue;
+			}
+			if (ch == '{') {
+				depth++;
+				append(ch);
+				nextChar();
+				continue;
+			}
+			if (ch == '}') {
+				depth--;
+				append(ch);
+				nextChar();
+				continue;
+			}
+			append(ch);
+			nextChar();
 		}
 	}
 

--- a/common/src/main/java/org/phoenixctms/ctsms/util/JavaScriptCompressor.java
+++ b/common/src/main/java/org/phoenixctms/ctsms/util/JavaScriptCompressor.java
@@ -131,6 +131,9 @@ public class JavaScriptCompressor {
 	/** Bounds scanning so comment/regex edge cases cannot spin forever. */
 	private int steps;
 	private final int maxSteps;
+	/** Caps mutual recursion between template literals and ${...} expressions. */
+	private static final int MAX_TEMPLATE_NESTING = 64;
+	private int templateNesting;
 
 	/**
 	 * Creates a new <code>JavaScriptCompressor</code> instance.
@@ -173,6 +176,16 @@ public class JavaScriptCompressor {
 				nextChar();
 			}
 		}
+	}
+
+	private void enterTemplateNesting() {
+		if (++templateNesting > MAX_TEMPLATE_NESTING) {
+			throw new IllegalStateException("JavaScriptCompressor template nesting limit exceeded");
+		}
+	}
+
+	private void leaveTemplateNesting() {
+		templateNesting--;
 	}
 
 	/**
@@ -267,36 +280,41 @@ public class JavaScriptCompressor {
 	 * awareness so the closing backtick is not missed.
 	 */
 	private void renderTemplateLiteral() {
-		append(ch); // opening `
-		nextChar();
-		while (!endReached) {
-			if (ch == '\\') {
-				append(ch);
-				nextChar();
-				if (endReached) {
-					return;
-				}
-				append(ch);
-				nextChar();
-				continue;
-			}
-			if (ch == '`') {
-				append(ch);
-				nextChar();
-				return;
-			}
-			if (ch == '$') {
-				append(ch);
-				nextChar();
-				if (ch == '{') {
+		enterTemplateNesting();
+		try {
+			append(ch); // opening `
+			nextChar();
+			while (!endReached) {
+				if (ch == '\\') {
 					append(ch);
 					nextChar();
-					renderTemplateExpression();
+					if (endReached) {
+						return;
+					}
+					append(ch);
+					nextChar();
+					continue;
 				}
-				continue;
+				if (ch == '`') {
+					append(ch);
+					nextChar();
+					return;
+				}
+				if (ch == '$') {
+					append(ch);
+					nextChar();
+					if (ch == '{') {
+						append(ch);
+						nextChar();
+						renderTemplateExpression();
+					}
+					continue;
+				}
+				append(ch); // newlines, quotes, /*, //, etc.
+				nextChar();
 			}
-			append(ch); // newlines, quotes, /*, //, etc.
-			nextChar();
+		} finally {
+			leaveTemplateNesting();
 		}
 	}
 
@@ -305,65 +323,70 @@ public class JavaScriptCompressor {
 	 * respecting nested braces, strings, templates, and comments.
 	 */
 	private void renderTemplateExpression() {
-		int depth = 1;
-		while (!endReached && depth > 0) {
-			if (ch == '"' || ch == '\'') {
-				renderString();
-				continue;
-			}
-			if (ch == '`') {
-				renderTemplateLiteral();
-				continue;
-			}
-			if (ch == '/') {
-				nextChar();
-				if (ch == '/') {
-					append('/');
-					append('/');
-					nextChar();
-					while (!endReached && ch != LINE_FEED && ch != CARRIAGE_RETURN) {
-						append(ch);
-						nextChar();
-					}
+		enterTemplateNesting();
+		try {
+			int depth = 1;
+			while (!endReached && depth > 0) {
+				if (ch == '"' || ch == '\'') {
+					renderString();
 					continue;
 				}
-				if (ch == '*') {
-					append('/');
-					append('*');
+				if (ch == '`') {
+					renderTemplateLiteral();
+					continue;
+				}
+				if (ch == '/') {
 					nextChar();
-					while (!endReached) {
-						if (ch == '*') {
-							append(ch);
-							nextChar();
-							if (ch == '/') {
-								append(ch);
-								nextChar();
-								break;
-							}
-						} else {
+					if (ch == '/') {
+						append('/');
+						append('/');
+						nextChar();
+						while (!endReached && ch != LINE_FEED && ch != CARRIAGE_RETURN) {
 							append(ch);
 							nextChar();
 						}
+						continue;
 					}
+					if (ch == '*') {
+						append('/');
+						append('*');
+						nextChar();
+						while (!endReached) {
+							if (ch == '*') {
+								append(ch);
+								nextChar();
+								if (ch == '/') {
+									append(ch);
+									nextChar();
+									break;
+								}
+							} else {
+								append(ch);
+								nextChar();
+							}
+						}
+						continue;
+					}
+					append('/');
 					continue;
 				}
-				append('/');
-				continue;
-			}
-			if (ch == '{') {
-				depth++;
+				if (ch == '{') {
+					depth++;
+					append(ch);
+					nextChar();
+					continue;
+				}
+				if (ch == '}') {
+					depth--;
+					append(ch);
+					nextChar();
+					continue;
+				}
 				append(ch);
 				nextChar();
-				continue;
 			}
-			if (ch == '}') {
-				depth--;
-				append(ch);
-				nextChar();
-				continue;
-			}
-			append(ch);
-			nextChar();
+		} finally {
+			leaveTemplateNesting();
 		}
 	}
 

--- a/core/src/main/java/org/phoenixctms/ctsms/service/trial/TrialServiceImpl.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/service/trial/TrialServiceImpl.java
@@ -1054,13 +1054,7 @@ public class TrialServiceImpl
 	}
 
 	private void checkAddEcrfFieldInput(ECRFFieldInVO ecrfFieldIn, boolean checkDeferredConstraints) throws ServiceException {
-		// Bulk addUpdateEcrf (import) already holds a PESSIMISTIC_WRITE on the eCRF for the whole txn.
-		// Skipping INPUT_FIELD FOR UPDATE there avoids locking every linked field until commit.
-		if (checkDeferredConstraints) {
-			CheckIDUtil.checkInputFieldId(ecrfFieldIn.getFieldId(), this.getInputFieldDao(), LockMode.PESSIMISTIC_WRITE);
-		} else {
-			CheckIDUtil.checkInputFieldId(ecrfFieldIn.getFieldId(), this.getInputFieldDao());
-		}
+		CheckIDUtil.checkInputFieldId(ecrfFieldIn.getFieldId(), this.getInputFieldDao(), LockMode.PESSIMISTIC_WRITE);
 		Trial trial = CheckIDUtil.checkTrialId(ecrfFieldIn.getTrialId(), this.getTrialDao());
 		ServiceUtil.checkTrialLocked(trial);
 		ECRF ecrf = CheckIDUtil.checkEcrfId(ecrfFieldIn.getEcrfId(), this.getECRFDao());
@@ -1289,8 +1283,8 @@ public class TrialServiceImpl
 		if (ecrfFieldIn.getSection() != null && !ecrfFieldIn.getSection().trim().equals(ecrfFieldIn.getSection())) {
 			throw L10nUtil.initServiceException(ServiceExceptionCodes.WHITESPACE_ECRF_FIELD_SECTION, ecrfFieldIn.getSection());
 		}
-		boolean hasJsValueExpression = !CommonUtil.isEmptyString(JavaScriptCompressor.compress(ecrfFieldIn.getJsValueExpression()));
-		boolean hasJsOutputExpression = !CommonUtil.isEmptyString(JavaScriptCompressor.compress(ecrfFieldIn.getJsOutputExpression()));
+		boolean hasJsValueExpression = !JavaScriptCompressor.isEffectivelyEmpty(ecrfFieldIn.getJsValueExpression());
+		boolean hasJsOutputExpression = !JavaScriptCompressor.isEffectivelyEmpty(ecrfFieldIn.getJsOutputExpression());
 		if (CommonUtil.isEmptyString(ecrfFieldIn.getJsVariableName())) {
 			if (hasJsValueExpression || hasJsOutputExpression) {
 				throw L10nUtil.initServiceException(ServiceExceptionCodes.ECRF_FIELD_JS_VARIABLE_NAME_REQUIRED);
@@ -1539,10 +1533,10 @@ public class TrialServiceImpl
 
 	private void checkInquiryInput(InquiryInVO inquiryIn) throws ServiceException {
 		if (CommonUtil.isEmptyString(inquiryIn.getJsVariableName())) {
-			if (!CommonUtil.isEmptyString(JavaScriptCompressor.compress(inquiryIn.getJsValueExpression()))) {
+			if (!JavaScriptCompressor.isEffectivelyEmpty(inquiryIn.getJsValueExpression())) {
 				throw L10nUtil.initServiceException(ServiceExceptionCodes.INQUIRY_JS_VARIABLE_NAME_REQUIRED);
 			}
-			if (!CommonUtil.isEmptyString(JavaScriptCompressor.compress(inquiryIn.getJsOutputExpression()))) {
+			if (!JavaScriptCompressor.isEffectivelyEmpty(inquiryIn.getJsOutputExpression())) {
 				throw L10nUtil.initServiceException(ServiceExceptionCodes.INQUIRY_JS_VARIABLE_NAME_REQUIRED);
 			}
 		} else {
@@ -1724,10 +1718,10 @@ public class TrialServiceImpl
 
 	private void checkProbandListEntryTagInput(ProbandListEntryTagInVO listTagIn, Trial trial, InputField field) throws ServiceException {
 		if (CommonUtil.isEmptyString(listTagIn.getJsVariableName())) {
-			if (!CommonUtil.isEmptyString(JavaScriptCompressor.compress(listTagIn.getJsValueExpression()))) {
+			if (!JavaScriptCompressor.isEffectivelyEmpty(listTagIn.getJsValueExpression())) {
 				throw L10nUtil.initServiceException(ServiceExceptionCodes.PROBAND_LIST_ENTRY_TAG_JS_VARIABLE_NAME_REQUIRED);
 			}
-			if (!CommonUtil.isEmptyString(JavaScriptCompressor.compress(listTagIn.getJsOutputExpression()))) {
+			if (!JavaScriptCompressor.isEffectivelyEmpty(listTagIn.getJsOutputExpression())) {
 				throw L10nUtil.initServiceException(ServiceExceptionCodes.PROBAND_LIST_ENTRY_TAG_JS_VARIABLE_NAME_REQUIRED);
 			}
 		} else {
@@ -2089,13 +2083,7 @@ public class TrialServiceImpl
 	}
 
 	private void checkUpdateEcrfFieldInput(ECRFField originalEcrfField, ECRFFieldInVO ecrfFieldIn, boolean checkDeferredConstraints) throws ServiceException {
-		// See checkAddEcrfFieldInput: bulk path skips INPUT_FIELD row locks; interactive path keeps them.
-		InputField field;
-		if (checkDeferredConstraints) {
-			field = CheckIDUtil.checkInputFieldId(ecrfFieldIn.getFieldId(), this.getInputFieldDao(), LockMode.PESSIMISTIC_WRITE);
-		} else {
-			field = CheckIDUtil.checkInputFieldId(ecrfFieldIn.getFieldId(), this.getInputFieldDao());
-		}
+		InputField field = CheckIDUtil.checkInputFieldId(ecrfFieldIn.getFieldId(), this.getInputFieldDao(), LockMode.PESSIMISTIC_WRITE);
 		Trial trial = CheckIDUtil.checkTrialId(ecrfFieldIn.getTrialId(), this.getTrialDao());
 		if (!trial.equals(originalEcrfField.getTrial())) {
 			throw L10nUtil.initServiceException(ServiceExceptionCodes.ECRF_FIELD_TRIAL_CHANGED);

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/inputfield/InputModel.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/inputfield/InputModel.java
@@ -421,7 +421,7 @@ public abstract class InputModel extends InputFieldOutVOConfigBase {
 	}
 
 	public final boolean isJsValueExpressionEmpty() {
-		return CommonUtil.isEmptyString(JavaScriptCompressor.compress(getJsValueExpression()));
+		return JavaScriptCompressor.isEffectivelyEmpty(getJsValueExpression());
 	}
 
 	public abstract boolean isJsVariable();


### PR DESCRIPTION
Replace Closure with a bounded emptiness scan for validation, restore Echo compress for UI with a step limit, and revert bulk INPUT_FIELD lock skipping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of empty JavaScript expressions, including values containing only whitespace or comments.
  * Prevented unsafe JavaScript minification by falling back to the original script when compression can’t complete reliably.
  * Tightened trial input validation and referential locking behavior for linked input fields.
* **Refactor**
  * Switched JavaScript minification to an integrated in-app compressor with safer handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->