### PR TITLE
fix select-one apply setValue and reject multi-id calculated values

### DIFF
--- a/core/src/main/resources/fieldCalculation.js
+++ b/core/src/main/resources/fieldCalculation.js
@@ -23,6 +23,7 @@ var FIELD_CALCULATION_OVERRIDE_CALCULATED_VALUES = true;
 	    'mustBeUnchecked'        : " darf nicht angekreuzt sein",
 	    'mustBeUnselected'       : " darf nicht gesetzt sein",
 	    'mustBeUnmarked'         : " darf nicht markiert sein",
+	    'selectOneMultipleSelectionIds' : "darf höchstens eine Auswahl-ID liefern (erhalten: %d)",
 
 	    'true'                   : "angekreuzt",
 	    'false'                  : "nicht angekreuzt",
@@ -81,6 +82,7 @@ var FIELD_CALCULATION_OVERRIDE_CALCULATED_VALUES = true;
 	    'mustBeUnchecked'        : " must be unchecked",
 	    'mustBeUnselected'       : " must not be selected",
 	    'mustBeUnmarked'         : " must not be marked",
+	    'selectOneMultipleSelectionIds' : "must return at most one selection id (got %d)",
 
 	    'true'                   : "checked",
 	    'false'                  : "unchecked",
@@ -387,7 +389,17 @@ var FIELD_CALCULATION_OVERRIDE_CALCULATED_VALUES = true;
 			if (evaluation != null) {
 				inputFieldVariable.oldValue = _cloneJSON(inputFieldVariable.value);
 				inputFieldVariable.valueErrorMessage = evaluation.errorMessage;
-				_setInputFieldVariableValue(inputFieldVariable.value, evaluation.returnValue);
+				if (evaluation.errorMessage == null || evaluation.errorMessage.length == 0) {
+					try {
+						_setInputFieldVariableValue(inputFieldVariable.value, evaluation.returnValue);
+					} catch (e) {
+						if (_testPropertyExists(e, 'msg')) {
+							inputFieldVariable.valueErrorMessage = e.msg;
+						} else {
+							inputFieldVariable.valueErrorMessage = "value expression " + inputFieldVariable.value.jsVariableName + ": " + e.toString();
+						}
+					}
+				}
 			}
 
 
@@ -1466,6 +1478,15 @@ var FIELD_CALCULATION_OVERRIDE_CALCULATED_VALUES = true;
 						}
 					}
 				}
+				if ((inputFieldVariableValue.inputFieldType == "SELECT_ONE_DROPDOWN"
+						|| inputFieldVariableValue.inputFieldType == "SELECT_ONE_RADIO_H"
+						|| inputFieldVariableValue.inputFieldType == "SELECT_ONE_RADIO_V")
+						&& newValue.length > 1) {
+					var locale = (inputFieldVars.locale != null && (inputFieldVars.locale in localizedMessages)) ? inputFieldVars.locale : defaultLocale;
+					var detail = sprintf(localizedMessages[locale]['selectOneMultipleSelectionIds'], newValue.length);
+					var variableName = inputFieldVariableValue.jsVariableName;
+					throw { msg: (variableName != null && variableName.length > 0) ? ("value expression " + variableName + ": " + detail) : detail };
+				}
 				inputFieldVariableValue.selectionValueIds = newValue;
 				break;
 			case "CHECKBOX":
@@ -2213,7 +2234,7 @@ var FIELD_CALCULATION_OVERRIDE_CALCULATED_VALUES = true;
 	function selectOneDropdownApplyCalculatedValue(variableName, index, widget, sourceId, rowId) {
 		silent = true;
 		var newValue = _inputFieldApplyCalculatedValue(variableName, index);
-		widget.setValue(newValue ? newValue[0] : null);
+		widget.setValue(newValue);
 		silent = false;
 		if (sourceId != null && sourceId.length > 0) {
 			ajaxRequest(sourceId, sourceId, null, null);
@@ -2223,7 +2244,7 @@ var FIELD_CALCULATION_OVERRIDE_CALCULATED_VALUES = true;
 	function selectOneRadioApplyCalculatedValue(variableName, index, widget, sourceId, rowId) {
 		silent = true;
 		var newValue = _inputFieldApplyCalculatedValue(variableName, index);
-		widget.setValue(newValue ? newValue[0] : null);
+		widget.setValue(newValue);
 		silent = false;
 		if (sourceId != null && sourceId.length > 0) {
 			ajaxRequest(sourceId, sourceId, null, null);

--- a/web/src/main/webapp/resources/js/fieldCalculation.js
+++ b/web/src/main/webapp/resources/js/fieldCalculation.js
@@ -23,6 +23,7 @@ var FIELD_CALCULATION_OVERRIDE_CALCULATED_VALUES = true;
 	    'mustBeUnchecked'        : " darf nicht angekreuzt sein",
 	    'mustBeUnselected'       : " darf nicht gesetzt sein",
 	    'mustBeUnmarked'         : " darf nicht markiert sein",
+	    'selectOneMultipleSelectionIds' : "darf höchstens eine Auswahl-ID liefern (erhalten: %d)",
 
 	    'true'                   : "angekreuzt",
 	    'false'                  : "nicht angekreuzt",
@@ -81,6 +82,7 @@ var FIELD_CALCULATION_OVERRIDE_CALCULATED_VALUES = true;
 	    'mustBeUnchecked'        : " must be unchecked",
 	    'mustBeUnselected'       : " must not be selected",
 	    'mustBeUnmarked'         : " must not be marked",
+	    'selectOneMultipleSelectionIds' : "must return at most one selection id (got %d)",
 
 	    'true'                   : "checked",
 	    'false'                  : "unchecked",
@@ -387,7 +389,17 @@ var FIELD_CALCULATION_OVERRIDE_CALCULATED_VALUES = true;
 			if (evaluation != null) {
 				inputFieldVariable.oldValue = _cloneJSON(inputFieldVariable.value);
 				inputFieldVariable.valueErrorMessage = evaluation.errorMessage;
-				_setInputFieldVariableValue(inputFieldVariable.value, evaluation.returnValue);
+				if (evaluation.errorMessage == null || evaluation.errorMessage.length == 0) {
+					try {
+						_setInputFieldVariableValue(inputFieldVariable.value, evaluation.returnValue);
+					} catch (e) {
+						if (_testPropertyExists(e, 'msg')) {
+							inputFieldVariable.valueErrorMessage = e.msg;
+						} else {
+							inputFieldVariable.valueErrorMessage = "value expression " + inputFieldVariable.value.jsVariableName + ": " + e.toString();
+						}
+					}
+				}
 			}
 
 
@@ -1466,6 +1478,15 @@ var FIELD_CALCULATION_OVERRIDE_CALCULATED_VALUES = true;
 						}
 					}
 				}
+				if ((inputFieldVariableValue.inputFieldType == "SELECT_ONE_DROPDOWN"
+						|| inputFieldVariableValue.inputFieldType == "SELECT_ONE_RADIO_H"
+						|| inputFieldVariableValue.inputFieldType == "SELECT_ONE_RADIO_V")
+						&& newValue.length > 1) {
+					var locale = (inputFieldVars.locale != null && (inputFieldVars.locale in localizedMessages)) ? inputFieldVars.locale : defaultLocale;
+					var detail = sprintf(localizedMessages[locale]['selectOneMultipleSelectionIds'], newValue.length);
+					var variableName = inputFieldVariableValue.jsVariableName;
+					throw { msg: (variableName != null && variableName.length > 0) ? ("value expression " + variableName + ": " + detail) : detail };
+				}
 				inputFieldVariableValue.selectionValueIds = newValue;
 				break;
 			case "CHECKBOX":
@@ -2213,7 +2234,7 @@ var FIELD_CALCULATION_OVERRIDE_CALCULATED_VALUES = true;
 	function selectOneDropdownApplyCalculatedValue(variableName, index, widget, sourceId, rowId) {
 		silent = true;
 		var newValue = _inputFieldApplyCalculatedValue(variableName, index);
-		widget.setValue(newValue ? newValue[0] : null);
+		widget.setValue(newValue);
 		silent = false;
 		if (sourceId != null && sourceId.length > 0) {
 			ajaxRequest(sourceId, sourceId, null, null);
@@ -2223,7 +2244,7 @@ var FIELD_CALCULATION_OVERRIDE_CALCULATED_VALUES = true;
 	function selectOneRadioApplyCalculatedValue(variableName, index, widget, sourceId, rowId) {
 		silent = true;
 		var newValue = _inputFieldApplyCalculatedValue(variableName, index);
-		widget.setValue(newValue ? newValue[0] : null);
+		widget.setValue(newValue);
 		silent = false;
 		if (sourceId != null && sourceId.length > 0) {
 			ajaxRequest(sourceId, sourceId, null, null);

--- a/web/src/main/webapp/resources/js/primefacesOverrides.js
+++ b/web/src/main/webapp/resources/js/primefacesOverrides.js
@@ -724,6 +724,10 @@ PrimeFaces.widget.SelectManyCheckbox.prototype.getValue = function() {
 
 PrimeFaces.widget.SelectManyCheckbox.prototype.setValue = function(value) {
 
+  // apply calculated value may pass null; treat as clear
+  if (value == null) {
+    value = [];
+  }
   if (value instanceof Array) {
     $(this.inputs).each(function() {
 
@@ -737,7 +741,8 @@ PrimeFaces.widget.SelectManyCheckbox.prototype.setValue = function(value) {
 		if (value[i] instanceof Array) {
 		  throw new Error('value element is an array');
 		}
-        if (value[i] === itemValue) {
+        // option values are strings; calculated selection ids may be numbers
+        if (value[i] == itemValue) {
           found = true;
           break;
         }
@@ -770,10 +775,16 @@ PrimeFaces.widget.SelectOneMenu.prototype.getValue = function() {
 
 PrimeFaces.widget.SelectOneMenu.prototype.setValue = function(value) {
 
+  // apply calculated value returns selection id array; [] / null => clear
+  if (value instanceof Array) {
+    value = value.length > 0 ? value[0] : null;
+  }
+
   var _self = this;
   var index = -1;
   for ( var i = 0; i < _self.options.length; i++) {
-    if (_self.options[i].value === value) {
+    // option values are strings; calculated selection ids may be numbers
+    if (_self.options[i].value == value) {
       index = _self.options[i].index;
       break;
     }
@@ -794,8 +805,13 @@ PrimeFaces.widget.SelectOneRadio.prototype.getValue = function() {
 
 PrimeFaces.widget.SelectOneRadio.prototype.setValue = function(value) {
 
+  // apply calculated value returns selection id array; [] / null => clear
+  if (value instanceof Array) {
+    value = value.length > 0 ? value[0] : null;
+  }
+
   var _self = this;
-  // unselect previous
+  // unselect previous visual
   _self.checkedRadio.removeClass('ui-state-active').children('.ui-radiobutton-icon').removeClass('ui-icon ui-icon-bullet');
 
   $(this.inputs).each(function() {
@@ -803,7 +819,8 @@ PrimeFaces.widget.SelectOneRadio.prototype.setValue = function(value) {
     var input = $(this);
     var radio = input.parent().next();
 
-    var found = (input.attr('value') === value);
+    // option values are strings; calculated selection ids may be numbers
+    var found = (value != null && value !== '' && input.attr('value') == value);
     if (found) {
       input.attr('checked', 'checked');
       radio.children('.ui-radiobutton-icon').addClass('ui-icon ui-icon-bullet');
@@ -812,6 +829,11 @@ PrimeFaces.widget.SelectOneRadio.prototype.setValue = function(value) {
         radio.addClass('ui-state-active');
       }
       _self.checkedRadio = radio;
+    } else {
+      // must clear other inputs; otherwise several stay :checked and getValue()
+      // returns the first (wrong) id — breaks valueEquals / delta after manual change
+      input.removeAttr('checked');
+      radio.removeClass('ui-state-active').children('.ui-radiobutton-icon').removeClass('ui-icon ui-icon-bullet');
     }
 
   });

--- a/web/src/main/webapp/resources/js/primefacesOverrides.js
+++ b/web/src/main/webapp/resources/js/primefacesOverrides.js
@@ -781,49 +781,17 @@ PrimeFaces.widget.SelectOneMenu.prototype.setValue = function(value) {
   }
 
   var _self = this;
-
-  // Empty calculated selection must clear backing <select> and panel UI.
-  // Otherwise null matches no option and the previous selection stays active.
-  if (value == null || value === '') {
-    _self.options.filter(':selected').removeAttr('selected');
-    var emptyOption = _self.options.filter('[value=""]');
-    if (emptyOption.length) {
-      emptyOption.attr('selected', 'selected');
-    }
-    if (_self.input && _self.input.length) {
-      _self.input.val('');
-    }
-    _self.value = '';
-    var emptyText = emptyOption.length ? emptyOption.text() : '';
-    if (_self.setLabel) {
-      _self.setLabel(emptyText);
-    } else if (_self.label && _self.label.length) {
-      if (_self.cfg && _self.cfg.editable) {
-        _self.label.val(emptyText);
-      } else {
-        _self.label.text(emptyText);
-      }
-    }
-    if (_self.focusItem) {
-      _self.focusItem.removeClass('ui-state-highlight');
-    }
-    if (_self.items && emptyOption.length) {
-      var emptyItem = _self.items.eq(emptyOption.index());
-      emptyItem.addClass('ui-state-highlight');
-      _self.focusItem = emptyItem;
-    }
-    return;
-  }
-
   var index = -1;
+  // null/undefined/'' -> no-selection option (empty string)
+  var matchValue = (value == null || value === '') ? '' : value;
   for ( var i = 0; i < _self.options.length; i++) {
     // option values are strings; calculated selection ids may be numbers
-    if (_self.options[i].value == value) {
+    if (_self.options[i].value == matchValue) {
       index = _self.options[i].index;
       break;
     }
   }
-  if (index > 0) {
+  if (index >= 0) {
     _self.selectItem(_self.items.eq(index));
   }
 

--- a/web/src/main/webapp/resources/js/primefacesOverrides.js
+++ b/web/src/main/webapp/resources/js/primefacesOverrides.js
@@ -781,6 +781,40 @@ PrimeFaces.widget.SelectOneMenu.prototype.setValue = function(value) {
   }
 
   var _self = this;
+
+  // Empty calculated selection must clear backing <select> and panel UI.
+  // Otherwise null matches no option and the previous selection stays active.
+  if (value == null || value === '') {
+    _self.options.filter(':selected').removeAttr('selected');
+    var emptyOption = _self.options.filter('[value=""]');
+    if (emptyOption.length) {
+      emptyOption.attr('selected', 'selected');
+    }
+    if (_self.input && _self.input.length) {
+      _self.input.val('');
+    }
+    _self.value = '';
+    var emptyText = emptyOption.length ? emptyOption.text() : '';
+    if (_self.setLabel) {
+      _self.setLabel(emptyText);
+    } else if (_self.label && _self.label.length) {
+      if (_self.cfg && _self.cfg.editable) {
+        _self.label.val(emptyText);
+      } else {
+        _self.label.text(emptyText);
+      }
+    }
+    if (_self.focusItem) {
+      _self.focusItem.removeClass('ui-state-highlight');
+    }
+    if (_self.items && emptyOption.length) {
+      var emptyItem = _self.items.eq(emptyOption.index());
+      emptyItem.addClass('ui-state-highlight');
+      _self.focusItem = emptyItem;
+    }
+    return;
+  }
+
   var index = -1;
   for ( var i = 0; i < _self.options.length; i++) {
     // option values are strings; calculated selection ids may be numbers


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and localized error messages when “select one” fields receive multiple selections.
  * Fixed calculated values that previously could fail silently or display incorrect error information.
  * Improved handling of calculated selections across dropdowns, radio buttons, and checkboxes.
  * Selection controls now clear correctly when values are empty or unavailable.
  * Improved compatibility when selection IDs are provided as either numbers or text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->