### PR TITLE
Fix selectMany grey frame and dead clicks after AJAX.

### DIFF
--- a/web/src/main/webapp/resources/css/default.css
+++ b/web/src/main/webapp/resources/css/default.css
@@ -32,6 +32,36 @@ td .ui-selectonemenu {
     margin: 3px 3px;
 }
 
+/*
+ * SelectManyCheckbox (PF 3.3.1): hidden inputs use position:absolute inside
+ * .ui-helper-hidden-accessible, but .ui-chkbox is not a positioning context
+ * (unlike .ui-radiobutton). After AJAX/reflow those helpers can cover the
+ * option list with theme chrome and steal clicks until a full reload.
+ */
+.ui-selectmanycheckbox .ui-chkbox {
+	position: relative;
+}
+
+.ui-selectmanycheckbox .ui-helper-hidden-accessible,
+.ui-selectoneradio .ui-helper-hidden-accessible {
+	width: 1px !important;
+	height: 1px !important;
+	margin: -1px !important;
+	padding: 0 !important;
+	overflow: hidden !important;
+	clip: rect(0, 0, 0, 0) !important;
+	border: 0 !important;
+}
+
+.ui-selectmanycheckbox,
+.ui-selectmanycheckbox tr,
+.ui-selectmanycheckbox td {
+	border: none !important;
+	background: none !important;
+	background-image: none !important;
+	box-shadow: none !important;
+}
+
 .ui-expanded-row-content  {
 	text-shadow: unset !important;
 }

--- a/web/src/main/webapp/resources/js/primefacesOverrides.js
+++ b/web/src/main/webapp/resources/js/primefacesOverrides.js
@@ -707,6 +707,50 @@ PrimeFaces.widget.SelectBooleanCheckbox.prototype.setValue = function(value) {
   }
 }
 
+// PF 3.3.1 BaseWidget.refresh() re-runs init/bindEvents without unbinding.
+// After AJAX that can stack handlers on surviving nodes; clear first.
+PrimeFaces.widget.SelectManyCheckbox.prototype.refresh = function(cfg) {
+  if (this.outputs) {
+    this.outputs.unbind();
+  }
+  if (this.inputs) {
+    this.inputs.unbind();
+  }
+  if (this.labels) {
+    this.labels.unbind();
+  }
+  return this.init(cfg);
+}
+
+PrimeFaces.widget.SelectOneRadio.prototype.refresh = function(cfg) {
+  if (this.outputs) {
+    this.outputs.unbind();
+  }
+  if (this.inputs) {
+    this.inputs.unbind();
+  }
+  if (this.labels) {
+    this.labels.unbind();
+  }
+  return this.init(cfg);
+}
+
+// Tooltip tips are moved to document.body; unbind old target handlers on ajax refresh.
+PrimeFaces.widget.Tooltip.prototype.refresh = function(cfg) {
+  if (this.target && this.cfg) {
+    if (this.cfg.showEvent) {
+      this.target.unbind(this.cfg.showEvent);
+    }
+    if (this.cfg.hideEvent) {
+      this.target.unbind(this.cfg.hideEvent);
+    }
+  }
+  if (this.timeout) {
+    clearTimeout(this.timeout);
+  }
+  return this.init(cfg);
+}
+
 PrimeFaces.widget.SelectManyCheckbox.prototype.getValue = function() {
 
   var result = [];


### PR DESCRIPTION
Contain absolute hidden checkbox inputs like radios, harden helper clipping, and unbind SelectMany/SelectOneRadio/Tooltip handlers on PrimeFaces refresh so partial updates cannot leave a covering layer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the appearance and layout of select-many checkboxes and select-one radio buttons.
  * Fixed refresh behavior to prevent duplicate interactions after components update.
  * Improved tooltip refresh handling by clearing outdated events and pending actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->