### PR TITLE
Prevent browser autofill site-wide except on login.

### DIFF
--- a/web/src/main/webapp/login.xhtml
+++ b/web/src/main/webapp/login.xhtml
@@ -70,6 +70,7 @@
 							<h:panelGroup>
 								<p:inputText id="username" value="#{sessionScopeBean.username}"
 									required="true" label="#{labels.login_username}"
+									autocomplete="username"
 									styleClass="ctsms-control" />
 								<p:tooltip rendered="false" for="username">
 									<h:outputText value="#{labels.login_username_tooltip}"
@@ -82,7 +83,7 @@
 							<h:panelGroup>
 								<p:password id="password" value="#{sessionScopeBean.password}"
 									required="false" feedback="false"
-									autocomplete="new-password"
+									autocomplete="current-password"
 									redisplay="#{sessionScopeBean.localPasswordRequired}"
 									label="#{labels.login_password}" styleClass="ctsms-password" />
 								<p:tooltip rendered="false" for="password">

--- a/web/src/main/webapp/resources/js/common.js
+++ b/web/src/main/webapp/resources/js/common.js
@@ -1609,7 +1609,7 @@ var AUTOFILL_READONLY_TYPES = {
 	time : true
 };
 
-function disableBrowserAutofill(root) {
+function disableBrowserAutofill(root, reinit) {
 	if (typeof IS_LOGIN_WINDOW !== 'undefined' && IS_LOGIN_WINDOW) {
 		return;
 	}
@@ -1626,14 +1626,34 @@ function disableBrowserAutofill(root) {
 		$el.attr('autocomplete', 'ctsms-off');
 		var useReadonly = tag === 'textarea'
 				|| (tag === 'input' && (!type || AUTOFILL_READONLY_TYPES[type]));
-		if (!useReadonly || $el.data('ctsmsAutofillGuard')) {
+		if (!useReadonly) {
+			return;
+		}
+		if (reinit) {
+			$el.removeData('ctsmsAutofillGuard');
+			$el.removeData('ctsmsAutofillUnlocked');
+			$el.off('focus.ctsmsAutofill');
+		}
+		// User already unlocked this field; keep editable across AJAX (e.g. autocomplete).
+		if ($el.data('ctsmsAutofillUnlocked')) {
+			return;
+		}
+		// Stale guard: marked protected but editable again without unlock (reused/reinit).
+		if ($el.data('ctsmsAutofillGuard') && !$el.prop('readonly')) {
+			$el.removeData('ctsmsAutofillGuard');
+			$el.off('focus.ctsmsAutofill');
+		}
+		if ($el.data('ctsmsAutofillGuard')) {
 			return;
 		}
 		$el.data('ctsmsAutofillGuard', true);
-		if (!$el.prop('readonly')) {
+		if (!$el.prop('readonly') && $el[0] !== document.activeElement) {
 			$el.prop('readonly', true);
 			$el.one('focus.ctsmsAutofill', function() {
-				jQuery(this).prop('readonly', false);
+				jQuery(this)
+					.prop('readonly', false)
+					.removeData('ctsmsAutofillGuard')
+					.data('ctsmsAutofillUnlocked', true);
 			});
 		}
 	});

--- a/web/src/main/webapp/resources/js/common.js
+++ b/web/src/main/webapp/resources/js/common.js
@@ -1581,3 +1581,67 @@ function rgb2hex(rgb) {
     }
     return "#" + hex(rgb[1]) + hex(rgb[2]) + hex(rgb[3]);
 }
+
+var AUTOFILL_SKIP_TYPES = {
+	hidden : true,
+	submit : true,
+	button : true,
+	checkbox : true,
+	radio : true,
+	file : true,
+	image : true,
+	reset : true
+};
+
+var AUTOFILL_READONLY_TYPES = {
+	text : true,
+	email : true,
+	tel : true,
+	search : true,
+	url : true,
+	password : true,
+	number : true,
+	date : true,
+	datetime : true,
+	'datetime-local' : true,
+	month : true,
+	week : true,
+	time : true
+};
+
+function disableBrowserAutofill(root) {
+	if (typeof IS_LOGIN_WINDOW !== 'undefined' && IS_LOGIN_WINDOW) {
+		return;
+	}
+	var $root = root ? jQuery(root) : jQuery(document);
+	$root.find('form').attr('autocomplete', 'off');
+	$root.find('input, textarea, select').each(function() {
+		var el = this;
+		var $el = jQuery(el);
+		var tag = (el.tagName || '').toLowerCase();
+		var type = (el.type || '').toLowerCase();
+		if (tag === 'input' && AUTOFILL_SKIP_TYPES[type]) {
+			return;
+		}
+		$el.attr('autocomplete', 'ctsms-off');
+		var useReadonly = tag === 'textarea'
+				|| (tag === 'input' && (!type || AUTOFILL_READONLY_TYPES[type]));
+		if (!useReadonly || $el.data('ctsmsAutofillGuard')) {
+			return;
+		}
+		$el.data('ctsmsAutofillGuard', true);
+		if (!$el.prop('readonly')) {
+			$el.prop('readonly', true);
+			$el.one('focus.ctsmsAutofill', function() {
+				jQuery(this).prop('readonly', false);
+			});
+		}
+	});
+}
+
+jQuery(function() {
+	disableBrowserAutofill();
+});
+jQuery(document).ajaxComplete(function() {
+	disableBrowserAutofill();
+});


### PR DESCRIPTION
Use ctsms-off and readonly-until-focus for forms after load/AJAX, and set login username/current-password tokens so password managers still work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved browser autofill behavior across the application.
  - Login forms now provide clearer username and current-password autofill hints.
  - Non-login forms reduce unwanted autofill suggestions while keeping fields editable when selected.
  - Autofill handling remains consistent after dynamic page updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->