### PR TITLE
Make PrimeFaces allowTypes file-extension regex case-insensitive.

### DIFF
--- a/common/src/main/java/org/phoenixctms/ctsms/util/CommonUtil.java
+++ b/common/src/main/java/org/phoenixctms/ctsms/util/CommonUtil.java
@@ -158,7 +158,9 @@ public final class CommonUtil {
 	private final static String DEFAULT_INPUT_DATETIME_PATTERN = DEFAULT_INPUT_DATE_PATTERN + " " + DEFAULT_INPUT_TIME_PATTERN; // "yyyy-MM-dd HH:mm"; //must not be locale
 	public final static String DIGITS_ONLY_DATETIME_PATTERN = "yyyyMMddHHmmss";
 	public final static boolean FILE_EXTENSION_REGEXP_MODE = true; // different primefaces versions(?), etc...
-	public final static String DEFAULT_FILE_EXTENSION_PATTERN = (FILE_EXTENSION_REGEXP_MODE ? "/(\\.|\\/)([a-zA-Z0-9]+)$/" : "*.*");
+	// Case-insensitive (/i): Windows/Office often keep uppercase extensions (.CSV); without /i,
+	// PrimeFaces allowTypes only matches via MIME (text/csv), which Office remaps to application/vnd.ms-excel.
+	public final static String DEFAULT_FILE_EXTENSION_PATTERN = (FILE_EXTENSION_REGEXP_MODE ? "/(\\.|\\/)([a-zA-Z0-9]+)$/i" : "*.*");
 	public final static Pattern FILE_EXTENSION_PATTERN_REGEXP = Pattern.compile("^\\*\\.[a-zA-Z0-9]+$");
 	public final static boolean HTML_SYSTEM_MESSAGES_COMMENTS = true;
 	public final static boolean HTML_AUDIT_TRAIL_CHANGE_COMMENTS = true;

--- a/core/src/main/java/org/phoenixctms/ctsms/service/shared/ToolsServiceImpl.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/service/shared/ToolsServiceImpl.java
@@ -806,7 +806,7 @@ public class ToolsServiceImpl
 						result.append(fileNameExtensionsString);
 						result.append(")");
 						try {
-							Pattern.compile(result.toString() + ")$/");
+							Pattern.compile(result.toString() + ")$/i");
 						} catch (PatternSyntaxException e) {
 							throw L10nUtil.initServiceException(ServiceExceptionCodes.INVALID_REGEXP_PATTERN_FROM_FILE_EXTENSION, fileNameExtensionsString, e.getMessage());
 						}
@@ -836,7 +836,7 @@ public class ToolsServiceImpl
 			throw L10nUtil.initServiceException(ServiceExceptionCodes.NO_MIME_TYPES_OR_FILE_EXTENSIONS);
 		}
 		if (CommonUtil.FILE_EXTENSION_REGEXP_MODE) {
-			result.append(")$/");
+			result.append(")$/i");
 		}
 		return result.toString();
 	}


### PR DESCRIPTION
Uppercase extensions like .CSV were rejected when Office remaps CSV MIME away from text/csv.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File extension validation now recognizes both uppercase and lowercase extensions.
  * File handling patterns consistently apply case-insensitive matching, improving compatibility with files that use uppercase extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->