### PR TITLE
Fix STRING_HASH search criterions to use bytelocate containment.

### DIFF
--- a/core/db/index-create.sql
+++ b/core/db/index-create.sql
@@ -139,7 +139,7 @@ create index journal_entry_criteria_fk_system_message_code ON JOURNAL_ENTRY (CRI
 -- When hash_for_search_word_substring_min_length is set, hash_for_search_word_substring_match_mode controls
 -- which substrings are hashed on persist (EXACT, START, END, ANYWHERE); hash_for_search_word_substring_case_insensitive
 -- optionally lowercases substrings before hashing. Store layout: exact full-string digest first (16 bytes), then
--- substring digests — EQ uses position(filter in col) = 1; reindex after changing any of these settings.
+-- substring digests — EQ uses bytelocate(?, col) = 1; reindex after changing any of these settings.
 --SELECT 'CREATE INDEX ' || table_name || '_' || column_name || ' ON ' || table_name || ' (' || column_name || ');' FROM information_schema.columns where table_catalog='ctsms' and right(column_name,5)='_hash';
 
 --CREATE INDEX medication_comment_hash ON medication (comment_hash);

--- a/core/db/index-create.sql
+++ b/core/db/index-create.sql
@@ -138,7 +138,8 @@ create index journal_entry_criteria_fk_system_message_code ON JOURNAL_ENTRY (CRI
 -- Uncomment when hash_for_search_word_substring_min_length=null (full-string hash only, fixed 16-byte blocks).
 -- When hash_for_search_word_substring_min_length is set, hash_for_search_word_substring_match_mode controls
 -- which substrings are hashed on persist (EXACT, START, END, ANYWHERE); hash_for_search_word_substring_case_insensitive
--- optionally lowercases substrings before hashing; reindex after changing any of these settings.
+-- optionally lowercases substrings before hashing. Store layout: exact full-string digest first (16 bytes), then
+-- substring digests — EQ uses position(filter in col) = 1; reindex after changing any of these settings.
 --SELECT 'CREATE INDEX ' || table_name || '_' || column_name || ' ON ' || table_name || ' (' || column_name || ');' FROM information_schema.columns where table_catalog='ctsms' and right(column_name,5)='_hash';
 
 --CREATE INDEX medication_comment_hash ON medication (comment_hash);

--- a/core/src/main/java/org/phoenixctms/ctsms/query/CriteriaUtil.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/query/CriteriaUtil.java
@@ -104,6 +104,8 @@ public final class CriteriaUtil {
 	private final static String ALTERNATIVE_FILTER_ALIAS_VARIANTS = "aliasVariants";
 	private final static HashMap<String, String[]> ALTERNATIVE_FILTER_MAP = new HashMap<String, String[]>();
 	static {
+		ALTERNATIVE_FILTER_MAP.put("ProbandContactParticulars.firstNameHash",
+				new String[] { ALTERNATIVE_FILTER_FIRST_NAME_VARIANTS });
 		ALTERNATIVE_FILTER_MAP.put("ProbandContactParticulars.lastNameHash",
 				new String[] { "alias", ALTERNATIVE_FILTER_FIRST_NAME_VARIANTS, ALTERNATIVE_FILTER_LAST_NAME_VARIANTS, ALTERNATIVE_FILTER_ALIAS_VARIANTS });
 		ALTERNATIVE_FILTER_MAP.put("PersonContactParticulars.lastName",

--- a/core/src/main/java/org/phoenixctms/ctsms/query/CriteriaUtil.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/query/CriteriaUtil.java
@@ -104,8 +104,6 @@ public final class CriteriaUtil {
 	private final static String ALTERNATIVE_FILTER_ALIAS_VARIANTS = "aliasVariants";
 	private final static HashMap<String, String[]> ALTERNATIVE_FILTER_MAP = new HashMap<String, String[]>();
 	static {
-		ALTERNATIVE_FILTER_MAP.put("ProbandContactParticulars.firstNameHash",
-				new String[] { ALTERNATIVE_FILTER_FIRST_NAME_VARIANTS });
 		ALTERNATIVE_FILTER_MAP.put("ProbandContactParticulars.lastNameHash",
 				new String[] { "alias", ALTERNATIVE_FILTER_FIRST_NAME_VARIANTS, ALTERNATIVE_FILTER_LAST_NAME_VARIANTS, ALTERNATIVE_FILTER_ALIAS_VARIANTS });
 		ALTERNATIVE_FILTER_MAP.put("PersonContactParticulars.lastName",

--- a/core/src/main/java/org/phoenixctms/ctsms/query/QueryUtil.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/query/QueryUtil.java
@@ -334,6 +334,22 @@ public final class QueryUtil {
 
 	private static void appendHashForSearchTextContainsHql(StringBuilder hqlWhereClause, ArrayList<QueryParameterValue> queryValues, String propertyName, String text)
 			throws Exception {
+		appendHashForSearchTextContainsHql(hqlWhereClause, queryValues, propertyName, text, false);
+	}
+
+	private static void appendHashForSearchTextContainsHql(StringBuilder hqlWhereClause, ArrayList<QueryParameterValue> queryValues, String propertyName, String text,
+			boolean caseInsensitive) throws Exception {
+		if (caseInsensitive) {
+			if (!CryptoUtil.isHashForSearchWordSubstringCaseInsensitive()) {
+				throw new IllegalArgumentException(L10nUtil.getMessage(MessageCodes.UNSUPPORTED_CRITERION_RESTRICTION,
+						DefaultMessages.UNSUPPORTED_CRITERION_RESTRICTION, new Object[] { "ILIKE" }));
+			}
+			if (CommonUtil.isEmptyString(text)) {
+				return;
+			}
+			appendHashForSearchContainsHql(hqlWhereClause, queryValues, propertyName, text.toLowerCase());
+			return;
+		}
 		List<String> variants = CryptoUtil.getHashForSearchFilterTextVariants(text);
 		if (variants.isEmpty()) {
 			return;
@@ -880,7 +896,7 @@ public final class QueryUtil {
 								if (CriterionValueType.STRING_HASH.equals(property.getValueType())
 										&& !CommonUtil.isEmptyString(criterion.getStringValue())) {
 									int before = queryValues.size();
-									appendHashForSearchTextContainsHql(hqlTerm, queryValues, propertyName, criterion.getStringValue());
+									appendHashForSearchTextContainsHql(hqlTerm, queryValues, propertyName, criterion.getStringValue(), true);
 									queryValueAdded = queryValues.size() > before;
 								} else {
 									hqlTerm.append("lower(");

--- a/core/src/main/java/org/phoenixctms/ctsms/query/QueryUtil.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/query/QueryUtil.java
@@ -106,13 +106,21 @@ public final class QueryUtil {
 	private final static String ALTERNATIVE_FILTER_LAST_NAME_VARIANTS = "lastNameVariants";
 	private final static String ALTERNATIVE_FILTER_ALIAS_VARIANTS = "aliasVariants";
 	private final static HashMap<String, String[]> ALTERNATIVE_FILTER_MAP = new HashMap<String, String[]>();
+	/** Field-scoped alternatives for search criterions (no cross-field ORs like lastName→firstName). */
+	private final static HashMap<String, String[]> CRITERION_ALTERNATIVE_FILTER_MAP = new HashMap<String, String[]>();
 	private final static HashMap<String, ArrayList<StaticCriterionTerm>> FIXED_CRITERION_TERMS_MAP = new HashMap<String, ArrayList<StaticCriterionTerm>>();
 	static {
+		ALTERNATIVE_FILTER_MAP.put("ProbandContactParticulars.firstNameHash",
+				new String[] { ALTERNATIVE_FILTER_FIRST_NAME_VARIANTS });
 		ALTERNATIVE_FILTER_MAP.put("ProbandContactParticulars.lastNameHash",
 				new String[] { "alias", ALTERNATIVE_FILTER_FIRST_NAME_VARIANTS, ALTERNATIVE_FILTER_LAST_NAME_VARIANTS, ALTERNATIVE_FILTER_ALIAS_VARIANTS });
 		ALTERNATIVE_FILTER_MAP.put("PersonContactParticulars.lastName",
 				new String[] { "firstName", ALTERNATIVE_FILTER_FIRST_NAME_VARIANTS, ALTERNATIVE_FILTER_LAST_NAME_VARIANTS });
 		ALTERNATIVE_FILTER_MAP.put("AnimalContactParticulars.animalName", new String[] { "alias" });
+		CRITERION_ALTERNATIVE_FILTER_MAP.put("ProbandContactParticulars.firstNameHash",
+				new String[] { ALTERNATIVE_FILTER_FIRST_NAME_VARIANTS });
+		CRITERION_ALTERNATIVE_FILTER_MAP.put("ProbandContactParticulars.lastNameHash",
+				new String[] { ALTERNATIVE_FILTER_LAST_NAME_VARIANTS });
 		addPropertyCriterionTerms("proband.diagnoses.code.systematics.blocks",
 				"proband.diagnoses.code.systematics.blocks.last", "{0} = ?",
 				new QueryParameterValue(true));
@@ -248,10 +256,24 @@ public final class QueryUtil {
 	private static AlternativeFilterRef applyAlternativeFilter(StringBuilder orHqlWhereClause, ArrayList<QueryParameterValue> orQueryValues, Class entityClass,
 			String entityName, AssociationPath filterFieldAssociationPath, String value, String timeZone, HashMap<String, AssociationPath> explicitJoinsMap,
 			HashMap<String, Class> propertyClassMap) throws Exception {
+		return applyAlternativeFilter(orHqlWhereClause, orQueryValues, entityClass, entityName, filterFieldAssociationPath, value, timeZone, explicitJoinsMap, propertyClassMap,
+				false, ALTERNATIVE_FILTER_MAP);
+	}
+
+	private static AlternativeFilterRef applyAlternativeFilter(StringBuilder orHqlWhereClause, ArrayList<QueryParameterValue> orQueryValues, Class entityClass,
+			String entityName, AssociationPath filterFieldAssociationPath, String value, String timeZone, HashMap<String, AssociationPath> explicitJoinsMap,
+			HashMap<String, Class> propertyClassMap, boolean exactHash) throws Exception {
+		return applyAlternativeFilter(orHqlWhereClause, orQueryValues, entityClass, entityName, filterFieldAssociationPath, value, timeZone, explicitJoinsMap, propertyClassMap,
+				exactHash, ALTERNATIVE_FILTER_MAP);
+	}
+
+	private static AlternativeFilterRef applyAlternativeFilter(StringBuilder orHqlWhereClause, ArrayList<QueryParameterValue> orQueryValues, Class entityClass,
+			String entityName, AssociationPath filterFieldAssociationPath, String value, String timeZone, HashMap<String, AssociationPath> explicitJoinsMap,
+			HashMap<String, Class> propertyClassMap, boolean exactHash, HashMap<String, String[]> alternativeFilterMap) throws Exception {
 		AlternativeFilterRef result = new AlternativeFilterRef();
 		Class pathClass = propertyClassMap.get(filterFieldAssociationPath.getPathString());
 		if (pathClass != null) {
-			String[] altFilterArr = ALTERNATIVE_FILTER_MAP.get(pathClass.getSimpleName() + AssociationPath.ASSOCIATION_PATH_SEPARATOR
+			String[] altFilterArr = alternativeFilterMap.get(pathClass.getSimpleName() + AssociationPath.ASSOCIATION_PATH_SEPARATOR
 					+ filterFieldAssociationPath.getPropertyName());
 			if (altFilterArr != null && altFilterArr.length > 0) {
 				for (int i = altFilterArr.length - 1; i >= 0; i--) {
@@ -267,8 +289,16 @@ public final class QueryUtil {
 								String variantPropertyName = aliasPropertyName(entityClass, variantPath, entityName, explicitJoinsMap, propertyClassMap);
 								StringBuilder variantHql = new StringBuilder();
 								ArrayList<QueryParameterValue> variantQueryValues = new ArrayList<QueryParameterValue>();
-								appendNormalizedHashVariantsOr(variantHql, variantQueryValues, variantPropertyName,
-										CommonUtil.getOrganisationNameVariants(value).iterator());
+								if (exactHash) {
+									// EQ/NE: one normalized form; prefix locate (= 1) after full-digest-first store layout
+									String normalized = ALTERNATIVE_FILTER_FIRST_NAME_VARIANTS.equals(altFilter)
+											? CommonUtil.normalizeFirstName(value)
+											: CommonUtil.normalizeLastName(value);
+									appendHashForSearchEqHql(variantHql, variantQueryValues, variantPropertyName, normalized);
+								} else {
+									appendNormalizedHashVariantsOr(variantHql, variantQueryValues, variantPropertyName,
+											CommonUtil.getOrganisationNameVariants(value).iterator());
+								}
 								if (variantHql.length() > 0) {
 									if (orHqlWhereClause.length() > 0) {
 										orHqlWhereClause.append(" or ");
@@ -330,6 +360,67 @@ public final class QueryUtil {
 		CriterionInstantVO criterion = new CriterionInstantVO();
 		criterion.setStringValue(text);
 		queryValues.add(new QueryParameterValue(propertyName, CriterionValueType.STRING_HASH, criterion));
+	}
+
+	/** EQ: full-string digest is stored as the leading block — match prefix only. */
+	private static void appendHashForSearchEqHql(StringBuilder hqlWhereClause, ArrayList<QueryParameterValue> queryValues, String propertyName, String text)
+			throws Exception {
+		if (CommonUtil.isEmptyString(text)) {
+			return;
+		}
+		hqlWhereClause.append("bytelocate(?, ");
+		hqlWhereClause.append(propertyName);
+		hqlWhereClause.append(") = 1");
+		CriterionInstantVO criterion = new CriterionInstantVO();
+		criterion.setStringValue(text);
+		queryValues.add(new QueryParameterValue(propertyName, CriterionValueType.STRING_HASH, criterion));
+	}
+
+	private static boolean appendStringHashCriterionHql(StringBuilder hqlTerm, ArrayList<QueryParameterValue> queryValues, String propertyName,
+			AssociationPath propertyNameAssociationPath, String text, Class entityClass, String entityName, HashMap<String, AssociationPath> explicitJoinsMap,
+			HashMap<String, Class> propertyClassMap, boolean caseInsensitive, boolean negate, boolean exact) throws Exception {
+		if (CommonUtil.isEmptyString(text)) {
+			return false;
+		}
+		StringBuilder altOrHqlWhereClause = new StringBuilder();
+		ArrayList<QueryParameterValue> altOrQueryValues = new ArrayList<QueryParameterValue>();
+		AlternativeFilterRef altFilterRef = applyAlternativeFilter(altOrHqlWhereClause, altOrQueryValues, entityClass, entityName, propertyNameAssociationPath, text, null,
+				explicitJoinsMap, propertyClassMap, exact, CRITERION_ALTERNATIVE_FILTER_MAP);
+		boolean hasAlt = altOrHqlWhereClause.length() > 0 || !CommonUtil.isEmptyString(altFilterRef.orPropertyName);
+		int before = queryValues.size();
+		if (negate) {
+			hqlTerm.append("not (");
+		}
+		if (hasAlt) {
+			hqlTerm.append("(");
+		}
+		if (exact) {
+			appendHashForSearchEqHql(hqlTerm, queryValues, propertyName, text);
+		} else {
+			appendHashForSearchTextContainsHql(hqlTerm, queryValues, propertyName, text, caseInsensitive);
+		}
+		if (altOrHqlWhereClause.length() > 0) {
+			hqlTerm.append(" or ");
+			hqlTerm.append(altOrHqlWhereClause);
+			queryValues.addAll(altOrQueryValues);
+		}
+		if (!CommonUtil.isEmptyString(altFilterRef.orPropertyName)) {
+			hqlTerm.append(" or ");
+			if (exact && altFilterRef.orPropertyClass != null && altFilterRef.orPropertyClass.equals(String.class)) {
+				hqlTerm.append(altFilterRef.orPropertyName);
+				hqlTerm.append(" = ?");
+				queryValues.add(new QueryParameterValue(String.class, text));
+			} else {
+				applyFilter(hqlTerm, queryValues, altFilterRef.orPropertyName, altFilterRef.orPropertyClass, text, null, null, null);
+			}
+		}
+		if (hasAlt) {
+			hqlTerm.append(")");
+		}
+		if (negate) {
+			hqlTerm.append(")");
+		}
+		return queryValues.size() > before;
 	}
 
 	private static void appendHashForSearchTextContainsHql(StringBuilder hqlWhereClause, ArrayList<QueryParameterValue> queryValues, String propertyName, String text)
@@ -844,9 +935,8 @@ public final class QueryUtil {
 							case EQ:
 								if (CriterionValueType.STRING_HASH.equals(property.getValueType())
 										&& !CommonUtil.isEmptyString(criterion.getStringValue())) {
-									int before = queryValues.size();
-									appendHashForSearchTextContainsHql(hqlTerm, queryValues, propertyName, criterion.getStringValue());
-									queryValueAdded = queryValues.size() > before;
+									queryValueAdded = appendStringHashCriterionHql(hqlTerm, queryValues, propertyName, propertyNameAssociationPath,
+											criterion.getStringValue(), entityClass, entityName, explicitJoinsMap, propertyClassMap, false, false, true);
 								} else {
 									hqlTerm.append(propertyName);
 									hqlTerm.append(" = ?");
@@ -855,11 +945,8 @@ public final class QueryUtil {
 							case NE:
 								if (CriterionValueType.STRING_HASH.equals(property.getValueType())
 										&& !CommonUtil.isEmptyString(criterion.getStringValue())) {
-									int before = queryValues.size();
-									hqlTerm.append("not (");
-									appendHashForSearchTextContainsHql(hqlTerm, queryValues, propertyName, criterion.getStringValue());
-									hqlTerm.append(")");
-									queryValueAdded = queryValues.size() > before;
+									queryValueAdded = appendStringHashCriterionHql(hqlTerm, queryValues, propertyName, propertyNameAssociationPath,
+											criterion.getStringValue(), entityClass, entityName, explicitJoinsMap, propertyClassMap, false, true, true);
 								} else {
 									hqlTerm.append(propertyName);
 									hqlTerm.append(" != ?");
@@ -884,9 +971,8 @@ public final class QueryUtil {
 							case LIKE:
 								if (CriterionValueType.STRING_HASH.equals(property.getValueType())
 										&& !CommonUtil.isEmptyString(criterion.getStringValue())) {
-									int before = queryValues.size();
-									appendHashForSearchTextContainsHql(hqlTerm, queryValues, propertyName, criterion.getStringValue());
-									queryValueAdded = queryValues.size() > before;
+									queryValueAdded = appendStringHashCriterionHql(hqlTerm, queryValues, propertyName, propertyNameAssociationPath,
+											criterion.getStringValue(), entityClass, entityName, explicitJoinsMap, propertyClassMap, false, false, false);
 								} else {
 									hqlTerm.append(propertyName);
 									hqlTerm.append(" like ?");
@@ -895,9 +981,8 @@ public final class QueryUtil {
 							case ILIKE:
 								if (CriterionValueType.STRING_HASH.equals(property.getValueType())
 										&& !CommonUtil.isEmptyString(criterion.getStringValue())) {
-									int before = queryValues.size();
-									appendHashForSearchTextContainsHql(hqlTerm, queryValues, propertyName, criterion.getStringValue(), true);
-									queryValueAdded = queryValues.size() > before;
+									queryValueAdded = appendStringHashCriterionHql(hqlTerm, queryValues, propertyName, propertyNameAssociationPath,
+											criterion.getStringValue(), entityClass, entityName, explicitJoinsMap, propertyClassMap, true, false, false);
 								} else {
 									hqlTerm.append("lower(");
 									hqlTerm.append(propertyName);

--- a/core/src/main/java/org/phoenixctms/ctsms/query/QueryUtil.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/query/QueryUtil.java
@@ -319,10 +319,10 @@ public final class QueryUtil {
 		return result;
 	}
 
-	private static void appendHashForSearchContainsHql(StringBuilder hqlWhereClause, ArrayList<QueryParameterValue> queryValues, String propertyName, String text)
+	private static boolean appendHashForSearchContainsHql(StringBuilder hqlWhereClause, ArrayList<QueryParameterValue> queryValues, String propertyName, String text)
 			throws Exception {
 		if (CommonUtil.isEmptyString(text)) {
-			return;
+			return false;
 		}
 		hqlWhereClause.append("bytelocate(?, ");
 		hqlWhereClause.append(propertyName);
@@ -330,13 +330,14 @@ public final class QueryUtil {
 		CriterionInstantVO criterion = new CriterionInstantVO();
 		criterion.setStringValue(text);
 		queryValues.add(new QueryParameterValue(propertyName, CriterionValueType.STRING_HASH, criterion));
+		return true;
 	}
 
 	/** EQ: full-string digest is stored as the leading block — match prefix only. */
-	private static void appendHashForSearchEqHql(StringBuilder hqlWhereClause, ArrayList<QueryParameterValue> queryValues, String propertyName, String text)
+	private static boolean appendHashForSearchEqHql(StringBuilder hqlWhereClause, ArrayList<QueryParameterValue> queryValues, String propertyName, String text)
 			throws Exception {
 		if (CommonUtil.isEmptyString(text)) {
-			return;
+			return false;
 		}
 		hqlWhereClause.append("bytelocate(?, ");
 		hqlWhereClause.append(propertyName);
@@ -344,42 +345,30 @@ public final class QueryUtil {
 		CriterionInstantVO criterion = new CriterionInstantVO();
 		criterion.setStringValue(text);
 		queryValues.add(new QueryParameterValue(propertyName, CriterionValueType.STRING_HASH, criterion));
+		return true;
 	}
 
-	private static void appendHashForSearchTextContainsHql(StringBuilder hqlWhereClause, ArrayList<QueryParameterValue> queryValues, String propertyName, String text)
+	private static boolean appendHashForSearchVariantsContainsHql(StringBuilder hqlWhereClause, ArrayList<QueryParameterValue> queryValues, String propertyName, String text)
 			throws Exception {
-		appendHashForSearchTextContainsHql(hqlWhereClause, queryValues, propertyName, text, false);
-	}
-
-	private static void appendHashForSearchTextContainsHql(StringBuilder hqlWhereClause, ArrayList<QueryParameterValue> queryValues, String propertyName, String text,
-			boolean caseInsensitive) throws Exception {
-		if (caseInsensitive) {
-			if (!CryptoUtil.isHashForSearchWordSubstringCaseInsensitive()) {
-				throw new IllegalArgumentException(L10nUtil.getMessage(MessageCodes.UNSUPPORTED_CRITERION_RESTRICTION,
-						DefaultMessages.UNSUPPORTED_CRITERION_RESTRICTION, new Object[] { "ILIKE" }));
-			}
-			if (CommonUtil.isEmptyString(text)) {
-				return;
-			}
-			appendHashForSearchContainsHql(hqlWhereClause, queryValues, propertyName, text.toLowerCase());
-			return;
-		}
 		List<String> variants = CryptoUtil.getHashForSearchFilterTextVariants(text);
 		if (variants.isEmpty()) {
-			return;
+			return false;
 		}
 		if (variants.size() == 1) {
-			appendHashForSearchContainsHql(hqlWhereClause, queryValues, propertyName, variants.get(0));
-			return;
+			return appendHashForSearchContainsHql(hqlWhereClause, queryValues, propertyName, variants.get(0));
 		}
 		hqlWhereClause.append("(");
+		boolean added = false;
 		for (int i = 0; i < variants.size(); i++) {
 			if (i > 0) {
 				hqlWhereClause.append(" or ");
 			}
-			appendHashForSearchContainsHql(hqlWhereClause, queryValues, propertyName, variants.get(i));
+			if (appendHashForSearchContainsHql(hqlWhereClause, queryValues, propertyName, variants.get(i))) {
+				added = true;
+			}
 		}
 		hqlWhereClause.append(")");
+		return added;
 	}
 
 	private static void appendNormalizedHashVariantsOr(StringBuilder hqlWhereClause, ArrayList<QueryParameterValue> queryValues, String propertyName,
@@ -391,7 +380,7 @@ public final class QueryUtil {
 				if (!first) {
 					hqlWhereClause.append(" or ");
 				}
-				appendHashForSearchTextContainsHql(hqlWhereClause, queryValues, propertyName, variantsIt.next()[0]);
+				appendHashForSearchVariantsContainsHql(hqlWhereClause, queryValues, propertyName, variantsIt.next()[0]);
 				first = false;
 			}
 			hqlWhereClause.append(")");
@@ -649,7 +638,7 @@ public final class QueryUtil {
 			}
 			//STRING_HASH:
 			hqlWhereClause.append(" or ");
-			appendHashForSearchTextContainsHql(hqlWhereClause, queryValues, propertyName, value);
+			appendHashForSearchVariantsContainsHql(hqlWhereClause, queryValues, propertyName, value);
 			//TIMESTAMP_HASH:
 			try {
 				Date date = CommonUtil.parseDate(value, CommonUtil.getInputDateTimePattern(CoreUtil.getUserContext().getDateFormat()), CommonUtil.timeZoneFromString(timeZone));
@@ -858,9 +847,7 @@ public final class QueryUtil {
 							case EQ:
 								if (CriterionValueType.STRING_HASH.equals(property.getValueType())
 										&& !CommonUtil.isEmptyString(criterion.getStringValue())) {
-									int before = queryValues.size();
-									appendHashForSearchEqHql(hqlTerm, queryValues, propertyName, criterion.getStringValue());
-									queryValueAdded = queryValues.size() > before;
+									queryValueAdded = appendHashForSearchEqHql(hqlTerm, queryValues, propertyName, criterion.getStringValue());
 								} else {
 									hqlTerm.append(propertyName);
 									hqlTerm.append(" = ?");
@@ -869,11 +856,9 @@ public final class QueryUtil {
 							case NE:
 								if (CriterionValueType.STRING_HASH.equals(property.getValueType())
 										&& !CommonUtil.isEmptyString(criterion.getStringValue())) {
-									int before = queryValues.size();
 									hqlTerm.append("not (");
-									appendHashForSearchEqHql(hqlTerm, queryValues, propertyName, criterion.getStringValue());
+									queryValueAdded = appendHashForSearchEqHql(hqlTerm, queryValues, propertyName, criterion.getStringValue());
 									hqlTerm.append(")");
-									queryValueAdded = queryValues.size() > before;
 								} else {
 									hqlTerm.append(propertyName);
 									hqlTerm.append(" != ?");
@@ -898,9 +883,7 @@ public final class QueryUtil {
 							case LIKE:
 								if (CriterionValueType.STRING_HASH.equals(property.getValueType())
 										&& !CommonUtil.isEmptyString(criterion.getStringValue())) {
-									int before = queryValues.size();
-									appendHashForSearchTextContainsHql(hqlTerm, queryValues, propertyName, criterion.getStringValue());
-									queryValueAdded = queryValues.size() > before;
+									queryValueAdded = appendHashForSearchContainsHql(hqlTerm, queryValues, propertyName, criterion.getStringValue());
 								} else {
 									hqlTerm.append(propertyName);
 									hqlTerm.append(" like ?");
@@ -909,9 +892,12 @@ public final class QueryUtil {
 							case ILIKE:
 								if (CriterionValueType.STRING_HASH.equals(property.getValueType())
 										&& !CommonUtil.isEmptyString(criterion.getStringValue())) {
-									int before = queryValues.size();
-									appendHashForSearchTextContainsHql(hqlTerm, queryValues, propertyName, criterion.getStringValue(), true);
-									queryValueAdded = queryValues.size() > before;
+									if (!CryptoUtil.isHashForSearchWordSubstringCaseInsensitive()) {
+										throw new IllegalArgumentException(L10nUtil.getMessage(MessageCodes.UNSUPPORTED_CRITERION_RESTRICTION,
+												DefaultMessages.UNSUPPORTED_CRITERION_RESTRICTION, new Object[] { "ILIKE" }));
+									}
+									queryValueAdded = appendHashForSearchContainsHql(hqlTerm, queryValues, propertyName,
+											criterion.getStringValue().toLowerCase());
 								} else {
 									hqlTerm.append("lower(");
 									hqlTerm.append(propertyName);

--- a/core/src/main/java/org/phoenixctms/ctsms/query/QueryUtil.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/query/QueryUtil.java
@@ -106,21 +106,13 @@ public final class QueryUtil {
 	private final static String ALTERNATIVE_FILTER_LAST_NAME_VARIANTS = "lastNameVariants";
 	private final static String ALTERNATIVE_FILTER_ALIAS_VARIANTS = "aliasVariants";
 	private final static HashMap<String, String[]> ALTERNATIVE_FILTER_MAP = new HashMap<String, String[]>();
-	/** Field-scoped alternatives for search criterions (no cross-field ORs like lastName→firstName). */
-	private final static HashMap<String, String[]> CRITERION_ALTERNATIVE_FILTER_MAP = new HashMap<String, String[]>();
 	private final static HashMap<String, ArrayList<StaticCriterionTerm>> FIXED_CRITERION_TERMS_MAP = new HashMap<String, ArrayList<StaticCriterionTerm>>();
 	static {
-		ALTERNATIVE_FILTER_MAP.put("ProbandContactParticulars.firstNameHash",
-				new String[] { ALTERNATIVE_FILTER_FIRST_NAME_VARIANTS });
 		ALTERNATIVE_FILTER_MAP.put("ProbandContactParticulars.lastNameHash",
 				new String[] { "alias", ALTERNATIVE_FILTER_FIRST_NAME_VARIANTS, ALTERNATIVE_FILTER_LAST_NAME_VARIANTS, ALTERNATIVE_FILTER_ALIAS_VARIANTS });
 		ALTERNATIVE_FILTER_MAP.put("PersonContactParticulars.lastName",
 				new String[] { "firstName", ALTERNATIVE_FILTER_FIRST_NAME_VARIANTS, ALTERNATIVE_FILTER_LAST_NAME_VARIANTS });
 		ALTERNATIVE_FILTER_MAP.put("AnimalContactParticulars.animalName", new String[] { "alias" });
-		CRITERION_ALTERNATIVE_FILTER_MAP.put("ProbandContactParticulars.firstNameHash",
-				new String[] { ALTERNATIVE_FILTER_FIRST_NAME_VARIANTS });
-		CRITERION_ALTERNATIVE_FILTER_MAP.put("ProbandContactParticulars.lastNameHash",
-				new String[] { ALTERNATIVE_FILTER_LAST_NAME_VARIANTS });
 		addPropertyCriterionTerms("proband.diagnoses.code.systematics.blocks",
 				"proband.diagnoses.code.systematics.blocks.last", "{0} = ?",
 				new QueryParameterValue(true));
@@ -256,24 +248,10 @@ public final class QueryUtil {
 	private static AlternativeFilterRef applyAlternativeFilter(StringBuilder orHqlWhereClause, ArrayList<QueryParameterValue> orQueryValues, Class entityClass,
 			String entityName, AssociationPath filterFieldAssociationPath, String value, String timeZone, HashMap<String, AssociationPath> explicitJoinsMap,
 			HashMap<String, Class> propertyClassMap) throws Exception {
-		return applyAlternativeFilter(orHqlWhereClause, orQueryValues, entityClass, entityName, filterFieldAssociationPath, value, timeZone, explicitJoinsMap, propertyClassMap,
-				false, ALTERNATIVE_FILTER_MAP);
-	}
-
-	private static AlternativeFilterRef applyAlternativeFilter(StringBuilder orHqlWhereClause, ArrayList<QueryParameterValue> orQueryValues, Class entityClass,
-			String entityName, AssociationPath filterFieldAssociationPath, String value, String timeZone, HashMap<String, AssociationPath> explicitJoinsMap,
-			HashMap<String, Class> propertyClassMap, boolean exactHash) throws Exception {
-		return applyAlternativeFilter(orHqlWhereClause, orQueryValues, entityClass, entityName, filterFieldAssociationPath, value, timeZone, explicitJoinsMap, propertyClassMap,
-				exactHash, ALTERNATIVE_FILTER_MAP);
-	}
-
-	private static AlternativeFilterRef applyAlternativeFilter(StringBuilder orHqlWhereClause, ArrayList<QueryParameterValue> orQueryValues, Class entityClass,
-			String entityName, AssociationPath filterFieldAssociationPath, String value, String timeZone, HashMap<String, AssociationPath> explicitJoinsMap,
-			HashMap<String, Class> propertyClassMap, boolean exactHash, HashMap<String, String[]> alternativeFilterMap) throws Exception {
 		AlternativeFilterRef result = new AlternativeFilterRef();
 		Class pathClass = propertyClassMap.get(filterFieldAssociationPath.getPathString());
 		if (pathClass != null) {
-			String[] altFilterArr = alternativeFilterMap.get(pathClass.getSimpleName() + AssociationPath.ASSOCIATION_PATH_SEPARATOR
+			String[] altFilterArr = ALTERNATIVE_FILTER_MAP.get(pathClass.getSimpleName() + AssociationPath.ASSOCIATION_PATH_SEPARATOR
 					+ filterFieldAssociationPath.getPropertyName());
 			if (altFilterArr != null && altFilterArr.length > 0) {
 				for (int i = altFilterArr.length - 1; i >= 0; i--) {
@@ -289,16 +267,8 @@ public final class QueryUtil {
 								String variantPropertyName = aliasPropertyName(entityClass, variantPath, entityName, explicitJoinsMap, propertyClassMap);
 								StringBuilder variantHql = new StringBuilder();
 								ArrayList<QueryParameterValue> variantQueryValues = new ArrayList<QueryParameterValue>();
-								if (exactHash) {
-									// EQ/NE: one normalized form; prefix locate (= 1) after full-digest-first store layout
-									String normalized = ALTERNATIVE_FILTER_FIRST_NAME_VARIANTS.equals(altFilter)
-											? CommonUtil.normalizeFirstName(value)
-											: CommonUtil.normalizeLastName(value);
-									appendHashForSearchEqHql(variantHql, variantQueryValues, variantPropertyName, normalized);
-								} else {
-									appendNormalizedHashVariantsOr(variantHql, variantQueryValues, variantPropertyName,
-											CommonUtil.getOrganisationNameVariants(value).iterator());
-								}
+								appendNormalizedHashVariantsOr(variantHql, variantQueryValues, variantPropertyName,
+										CommonUtil.getOrganisationNameVariants(value).iterator());
 								if (variantHql.length() > 0) {
 									if (orHqlWhereClause.length() > 0) {
 										orHqlWhereClause.append(" or ");
@@ -374,53 +344,6 @@ public final class QueryUtil {
 		CriterionInstantVO criterion = new CriterionInstantVO();
 		criterion.setStringValue(text);
 		queryValues.add(new QueryParameterValue(propertyName, CriterionValueType.STRING_HASH, criterion));
-	}
-
-	private static boolean appendStringHashCriterionHql(StringBuilder hqlTerm, ArrayList<QueryParameterValue> queryValues, String propertyName,
-			AssociationPath propertyNameAssociationPath, String text, Class entityClass, String entityName, HashMap<String, AssociationPath> explicitJoinsMap,
-			HashMap<String, Class> propertyClassMap, boolean caseInsensitive, boolean negate, boolean exact) throws Exception {
-		if (CommonUtil.isEmptyString(text)) {
-			return false;
-		}
-		StringBuilder altOrHqlWhereClause = new StringBuilder();
-		ArrayList<QueryParameterValue> altOrQueryValues = new ArrayList<QueryParameterValue>();
-		AlternativeFilterRef altFilterRef = applyAlternativeFilter(altOrHqlWhereClause, altOrQueryValues, entityClass, entityName, propertyNameAssociationPath, text, null,
-				explicitJoinsMap, propertyClassMap, exact, CRITERION_ALTERNATIVE_FILTER_MAP);
-		boolean hasAlt = altOrHqlWhereClause.length() > 0 || !CommonUtil.isEmptyString(altFilterRef.orPropertyName);
-		int before = queryValues.size();
-		if (negate) {
-			hqlTerm.append("not (");
-		}
-		if (hasAlt) {
-			hqlTerm.append("(");
-		}
-		if (exact) {
-			appendHashForSearchEqHql(hqlTerm, queryValues, propertyName, text);
-		} else {
-			appendHashForSearchTextContainsHql(hqlTerm, queryValues, propertyName, text, caseInsensitive);
-		}
-		if (altOrHqlWhereClause.length() > 0) {
-			hqlTerm.append(" or ");
-			hqlTerm.append(altOrHqlWhereClause);
-			queryValues.addAll(altOrQueryValues);
-		}
-		if (!CommonUtil.isEmptyString(altFilterRef.orPropertyName)) {
-			hqlTerm.append(" or ");
-			if (exact && altFilterRef.orPropertyClass != null && altFilterRef.orPropertyClass.equals(String.class)) {
-				hqlTerm.append(altFilterRef.orPropertyName);
-				hqlTerm.append(" = ?");
-				queryValues.add(new QueryParameterValue(String.class, text));
-			} else {
-				applyFilter(hqlTerm, queryValues, altFilterRef.orPropertyName, altFilterRef.orPropertyClass, text, null, null, null);
-			}
-		}
-		if (hasAlt) {
-			hqlTerm.append(")");
-		}
-		if (negate) {
-			hqlTerm.append(")");
-		}
-		return queryValues.size() > before;
 	}
 
 	private static void appendHashForSearchTextContainsHql(StringBuilder hqlWhereClause, ArrayList<QueryParameterValue> queryValues, String propertyName, String text)
@@ -935,8 +858,9 @@ public final class QueryUtil {
 							case EQ:
 								if (CriterionValueType.STRING_HASH.equals(property.getValueType())
 										&& !CommonUtil.isEmptyString(criterion.getStringValue())) {
-									queryValueAdded = appendStringHashCriterionHql(hqlTerm, queryValues, propertyName, propertyNameAssociationPath,
-											criterion.getStringValue(), entityClass, entityName, explicitJoinsMap, propertyClassMap, false, false, true);
+									int before = queryValues.size();
+									appendHashForSearchEqHql(hqlTerm, queryValues, propertyName, criterion.getStringValue());
+									queryValueAdded = queryValues.size() > before;
 								} else {
 									hqlTerm.append(propertyName);
 									hqlTerm.append(" = ?");
@@ -945,8 +869,11 @@ public final class QueryUtil {
 							case NE:
 								if (CriterionValueType.STRING_HASH.equals(property.getValueType())
 										&& !CommonUtil.isEmptyString(criterion.getStringValue())) {
-									queryValueAdded = appendStringHashCriterionHql(hqlTerm, queryValues, propertyName, propertyNameAssociationPath,
-											criterion.getStringValue(), entityClass, entityName, explicitJoinsMap, propertyClassMap, false, true, true);
+									int before = queryValues.size();
+									hqlTerm.append("not (");
+									appendHashForSearchEqHql(hqlTerm, queryValues, propertyName, criterion.getStringValue());
+									hqlTerm.append(")");
+									queryValueAdded = queryValues.size() > before;
 								} else {
 									hqlTerm.append(propertyName);
 									hqlTerm.append(" != ?");
@@ -971,8 +898,9 @@ public final class QueryUtil {
 							case LIKE:
 								if (CriterionValueType.STRING_HASH.equals(property.getValueType())
 										&& !CommonUtil.isEmptyString(criterion.getStringValue())) {
-									queryValueAdded = appendStringHashCriterionHql(hqlTerm, queryValues, propertyName, propertyNameAssociationPath,
-											criterion.getStringValue(), entityClass, entityName, explicitJoinsMap, propertyClassMap, false, false, false);
+									int before = queryValues.size();
+									appendHashForSearchTextContainsHql(hqlTerm, queryValues, propertyName, criterion.getStringValue());
+									queryValueAdded = queryValues.size() > before;
 								} else {
 									hqlTerm.append(propertyName);
 									hqlTerm.append(" like ?");
@@ -981,8 +909,9 @@ public final class QueryUtil {
 							case ILIKE:
 								if (CriterionValueType.STRING_HASH.equals(property.getValueType())
 										&& !CommonUtil.isEmptyString(criterion.getStringValue())) {
-									queryValueAdded = appendStringHashCriterionHql(hqlTerm, queryValues, propertyName, propertyNameAssociationPath,
-											criterion.getStringValue(), entityClass, entityName, explicitJoinsMap, propertyClassMap, true, false, false);
+									int before = queryValues.size();
+									appendHashForSearchTextContainsHql(hqlTerm, queryValues, propertyName, criterion.getStringValue(), true);
+									queryValueAdded = queryValues.size() > before;
 								} else {
 									hqlTerm.append("lower(");
 									hqlTerm.append(propertyName);

--- a/core/src/main/java/org/phoenixctms/ctsms/query/QueryUtil.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/query/QueryUtil.java
@@ -826,12 +826,28 @@ public final class QueryUtil {
 								hqlTerm.append(".id != ?");
 								break;
 							case EQ:
-								hqlTerm.append(propertyName);
-								hqlTerm.append(" = ?");
+								if (CriterionValueType.STRING_HASH.equals(property.getValueType())
+										&& !CommonUtil.isEmptyString(criterion.getStringValue())) {
+									int before = queryValues.size();
+									appendHashForSearchTextContainsHql(hqlTerm, queryValues, propertyName, criterion.getStringValue());
+									queryValueAdded = queryValues.size() > before;
+								} else {
+									hqlTerm.append(propertyName);
+									hqlTerm.append(" = ?");
+								}
 								break;
 							case NE:
-								hqlTerm.append(propertyName);
-								hqlTerm.append(" != ?");
+								if (CriterionValueType.STRING_HASH.equals(property.getValueType())
+										&& !CommonUtil.isEmptyString(criterion.getStringValue())) {
+									int before = queryValues.size();
+									hqlTerm.append("not (");
+									appendHashForSearchTextContainsHql(hqlTerm, queryValues, propertyName, criterion.getStringValue());
+									hqlTerm.append(")");
+									queryValueAdded = queryValues.size() > before;
+								} else {
+									hqlTerm.append(propertyName);
+									hqlTerm.append(" != ?");
+								}
 								break;
 							case GT:
 								hqlTerm.append(propertyName);
@@ -850,13 +866,27 @@ public final class QueryUtil {
 								hqlTerm.append(" <= ?");
 								break;
 							case LIKE:
-								hqlTerm.append(propertyName);
-								hqlTerm.append(" like ?");
+								if (CriterionValueType.STRING_HASH.equals(property.getValueType())
+										&& !CommonUtil.isEmptyString(criterion.getStringValue())) {
+									int before = queryValues.size();
+									appendHashForSearchTextContainsHql(hqlTerm, queryValues, propertyName, criterion.getStringValue());
+									queryValueAdded = queryValues.size() > before;
+								} else {
+									hqlTerm.append(propertyName);
+									hqlTerm.append(" like ?");
+								}
 								break;
 							case ILIKE:
-								hqlTerm.append("lower(");
-								hqlTerm.append(propertyName);
-								hqlTerm.append(") like lower(?)");
+								if (CriterionValueType.STRING_HASH.equals(property.getValueType())
+										&& !CommonUtil.isEmptyString(criterion.getStringValue())) {
+									int before = queryValues.size();
+									appendHashForSearchTextContainsHql(hqlTerm, queryValues, propertyName, criterion.getStringValue());
+									queryValueAdded = queryValues.size() > before;
+								} else {
+									hqlTerm.append("lower(");
+									hqlTerm.append(propertyName);
+									hqlTerm.append(") like lower(?)");
+								}
 								break;
 							case IS_EMPTY:
 								hqlTerm.append(propertyName);

--- a/core/src/main/java/org/phoenixctms/ctsms/security/CryptoUtil.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/security/CryptoUtil.java
@@ -488,10 +488,15 @@ public final class CryptoUtil {
 		if (substrings.isEmpty()) {
 			return hashForSearchValue(text);
 		}
+		// Leading block = exact full-string digest so EQ can use position(? in col) = 1
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		byte[] exactHash = hashForSearchValue(text);
+		if (exactHash != null) {
+			out.write(exactHash, 0, exactHash.length);
+		}
 		for (String substring : substrings) {
 			byte[] hash = hashForSearchValue(substring);
-			if (hash != null) {
+			if (hash != null && (exactHash == null || !Arrays.equals(hash, exactHash))) {
 				out.write(hash, 0, hash.length);
 			}
 		}
@@ -507,9 +512,13 @@ public final class CryptoUtil {
 			return hashForSearchValue(departmentKey, text);
 		}
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		byte[] exactHash = hashForSearchValue(departmentKey, text);
+		if (exactHash != null) {
+			out.write(exactHash, 0, exactHash.length);
+		}
 		for (String substring : substrings) {
 			byte[] hash = hashForSearchValue(departmentKey, substring);
-			if (hash != null) {
+			if (hash != null && (exactHash == null || !Arrays.equals(hash, exactHash))) {
 				out.write(hash, 0, hash.length);
 			}
 		}
@@ -525,9 +534,13 @@ public final class CryptoUtil {
 			return hashForSearchValue(salt, password, text);
 		}
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		byte[] exactHash = hashForSearchValue(salt, password, text);
+		if (exactHash != null) {
+			out.write(exactHash, 0, exactHash.length);
+		}
 		for (String substring : substrings) {
 			byte[] hash = hashForSearchValue(salt, password, substring);
-			if (hash != null) {
+			if (hash != null && (exactHash == null || !Arrays.equals(hash, exactHash))) {
 				out.write(hash, 0, hash.length);
 			}
 		}

--- a/core/src/main/java/org/phoenixctms/ctsms/security/CryptoUtil.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/security/CryptoUtil.java
@@ -456,7 +456,7 @@ public final class CryptoUtil {
 		return CommonUtil.generateWordSubstrings(text, minLength, getHashForSearchWordSubstringMatchMode(), isHashForSearchWordSubstringCaseInsensitive());
 	}
 
-	private static boolean isHashForSearchWordSubstringCaseInsensitive() {
+	public static boolean isHashForSearchWordSubstringCaseInsensitive() {
 		if (!Settings.getBoolean(SettingCodes.HASH_FOR_SEARCH_WORD_SUBSTRING_CASE_INSENSITIVE, Bundle.SETTINGS,
 				DefaultSettings.HASH_FOR_SEARCH_WORD_SUBSTRING_CASE_INSENSITIVE)) {
 			return false;


### PR DESCRIPTION
Search criterions still used =/like with a bare filter digest after applyFilter moved to position lookup, so hashed string fields never matched the concatenated store blob.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering for hashed string fields when using equals, not-equals, and partial-text search conditions.
  * Improved exact and case-sensitive or case-insensitive searches for names and other hashed text fields.
  * Ensured alternative name values are included in relevant searches.
  * Preserved standard comparison behavior when no searchable hash value is available.
  * Ensured not-equal searches return the correct results.
  * Improved search hash consistency by prioritizing exact matches and avoiding duplicate values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->