### PR TITLE
Cursor/ecrf clear pessimistic lock

### DIFF
--- a/core/src/main/java/org/phoenixctms/ctsms/service/proband/ProbandServiceImpl.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/service/proband/ProbandServiceImpl.java
@@ -2348,8 +2348,10 @@ public class ProbandServiceImpl
 	protected Collection<InquiryValueOutVO> handleClearInquiryValues(AuthenticationVO auth, Long trialId, String category, Long probandId) throws Exception {
 		Timestamp now = new Timestamp(System.currentTimeMillis());
 		User user = CoreUtil.getUser();
-		checkClearInquiryValues(trialId, probandId);
-		return clearInquiryValues(this.getTrialDao().load(trialId), this.getProbandDao().load(probandId),
+		Object[] locked = checkClearInquiryValues(trialId, probandId);
+		Trial trial = (Trial) locked[0];
+		Proband proband = (Proband) locked[1];
+		return clearInquiryValues(trial, proband,
 				ServiceUtil.getInquiryValues(this.getInquiryValueDao().findByProbandTrialCategoryActiveJs(probandId, trialId, category, null, null, true, null, null)), now, user);
 	}
 
@@ -2357,13 +2359,17 @@ public class ProbandServiceImpl
 	protected Collection<InquiryValueOutVO> handleClearInquiryValues(AuthenticationVO auth, Long trialId, Long probandId) throws Exception {
 		Timestamp now = new Timestamp(System.currentTimeMillis());
 		User user = CoreUtil.getUser();
-		checkClearInquiryValues(trialId, probandId);
-		return clearInquiryValues(this.getTrialDao().load(trialId), this.getProbandDao().load(probandId),
+		Object[] locked = checkClearInquiryValues(trialId, probandId);
+		Trial trial = (Trial) locked[0];
+		Proband proband = (Proband) locked[1];
+		return clearInquiryValues(trial, proband,
 				ServiceUtil.getInquiryValues(this.getInquiryValueDao().findByProbandTrialActiveJs(probandId, trialId, null, null, true, null, null)), now, user);
 	}
 
-	private void checkClearInquiryValues(Long trialId, Long probandId) throws Exception {
-		Trial trial = CheckIDUtil.checkTrialId(trialId, this.getTrialDao());
+	private Object[] checkClearInquiryValues(Long trialId, Long probandId) throws Exception {
+		// Lock trial then proband: concurrent clears of different probands still mutate shared
+		// inquiry.inquiryValues and can race on InputFieldValue deletes.
+		Trial trial = CheckIDUtil.checkTrialId(trialId, this.getTrialDao(), LockMode.PESSIMISTIC_WRITE);
 		ServiceUtil.checkTrialLocked(trial);
 		if (!trial.getStatus().isInquiryValueInputEnabled()) {
 			throw L10nUtil.initServiceException(ServiceExceptionCodes.INQUIRY_VALUE_INPUT_DISABLED_FOR_TRIAL,
@@ -2371,6 +2377,7 @@ public class ProbandServiceImpl
 		}
 		Proband proband = CheckIDUtil.checkProbandId(probandId, this.getProbandDao(), LockMode.PESSIMISTIC_WRITE);
 		ServiceUtil.checkProbandLocked(proband);
+		return new Object[] { trial, proband };
 	}
 
 	private ArrayList<InquiryValueOutVO> clearInquiryValues(Trial trial, Proband proband, Collection<InquiryValue> values,

--- a/core/src/main/java/org/phoenixctms/ctsms/service/trial/TrialServiceImpl.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/service/trial/TrialServiceImpl.java
@@ -1261,6 +1261,9 @@ public class TrialServiceImpl
 			throw L10nUtil.initServiceException(ServiceExceptionCodes.ECRF_FIELD_VALUE_INPUT_DISABLED_FOR_ECRF, ecrf.getName());
 		}
 		ProbandListEntry listEntry = CheckIDUtil.checkProbandListEntryId(probandListEntryId, this.getProbandListEntryDao(), LockMode.PESSIMISTIC_WRITE);
+		// Lock eCRF for clear as well: concurrent clears of different listentries still
+		// mutate shared ecrfField.fieldValues and can race on InputFieldValue deletes.
+		this.getECRFDao().lock(ecrf, LockMode.PESSIMISTIC_WRITE);
 		if (!ecrf.getTrial().equals(listEntry.getTrial())) {
 			throw L10nUtil.initServiceException(ServiceExceptionCodes.ECRF_FIELD_VALUES_FOR_WRONG_TRIAL);
 		}
@@ -1268,7 +1271,6 @@ public class TrialServiceImpl
 		ECRFStatusEntry statusEntry = this.getECRFStatusEntryDao().findByListEntryEcrfVisit(listEntry.getId(), ecrf.getId(), visit != null ? visit.getId() : null);
 		if (statusEntry == null) {
 			ECRFStatusType statusType = this.getECRFStatusTypeDao().findInitialStates().iterator().next();
-			this.getECRFDao().lock(ecrf, LockMode.PESSIMISTIC_WRITE);
 			Object[] resultItems = addEcrfStatusEntry(listEntry, ecrf, visit, statusType, null, now, user);
 			statusEntry = (ECRFStatusEntry) resultItems[0];
 		}
@@ -3642,7 +3644,7 @@ public class TrialServiceImpl
 		ProbandListEntry listEntry = checkClearEcrfFieldValues(probandListEntryId, ecrfId, visitId, now, user);
 		clearEcrfFieldStatusEntries(listEntry,
 				this.getECRFFieldStatusEntryDao().findByListEntryEcrfVisitSection(probandListEntryId, ecrfId, visitId, section, true, null), now, user);
-		return clearEcrfFieldValues(this.getProbandListEntryDao().load(probandListEntryId),
+		return clearEcrfFieldValues(listEntry,
 				this.getECRFFieldValueDao().findByListEntryEcrfVisitSection(probandListEntryId, ecrfId, visitId, section, true, null), now, user);
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when clearing inquiry and eCRF field values by applying consistent record locking.
  * Prevented conflicting updates during simultaneous clear operations.
  * Reduced unnecessary data reloading during section-specific clearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->