### PR TITLE
Add opt-in RestApi JWT re-issue on session keep-alive

### DIFF
--- a/.cursor/rules/mda-uml-commits.mdc
+++ b/.cursor/rules/mda-uml-commits.mdc
@@ -1,0 +1,13 @@
+---
+description: Always include all MDA UML files when committing model changes
+globs: mda/src/main/uml/**
+alwaysApply: false
+---
+
+# MDA / UML commits
+
+When committing AndroMDA / MagicDraw model changes under `mda/src/main/uml/`:
+
+- Include **all** modified files in that directory in the same UML/MDA commit (e.g. `ctsms.uml`, `ctsms.xml`, and every changed `*.profile.uml` / related profile file).
+- Do **not** leave MagicDraw/AndroMDA profile rewrites unstaged or split into a follow-up commit.
+- Prefer staging with `git add mda/src/main/uml/` (or equivalent) rather than cherry-picking individual UML files.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,4 +36,5 @@ jobs:
       - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-        run: mvn verify -DskipTests --no-transfer-progress -c
+        # sonar-maven-plugin is bound to verify in pom.xml; skip analysis in CI (no SONAR_TOKEN).
+        run: mvn verify -DskipTests -Dsonar.skip=true --no-transfer-progress -c

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,20 +27,13 @@ jobs:
         uses: stCarolas/setup-maven@v4.5
         with:
           maven-version: 3.8.7
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
         uses: actions/cache@v3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - name: Build and analyze
+      - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -DskipTests --no-transfer-progress -c
+        run: mvn verify -DskipTests --no-transfer-progress -c

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/InquiriesPDFDefaultSettings.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/InquiriesPDFDefaultSettings.java
@@ -72,6 +72,7 @@ public final class InquiriesPDFDefaultSettings {
 	public static final String PAINTER_CLASS = null;
 	public static final ArrayList<String> PAINTER_SOURCE_FILES = null;
 	public static final boolean DATE_TIME_USER_TIME_ZONE = true;
+	public static final boolean SHOW_QRCODE = true;
 	public static final Color QRCODE_COLOR = Color.BLACK;
 	public static final int QRCODE_IMAGE_WIDTH = 500;
 	public static final int QRCODE_IMAGE_HEIGHT = 500;

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/InquiriesPDFPainter.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/InquiriesPDFPainter.java
@@ -282,7 +282,8 @@ public class InquiriesPDFPainter extends PDFPainterBase implements PDFOutput {
 				}
 			}
 		}
-		if (listEntryVOs != null) {
+		if (listEntryVOs != null
+				&& Settings.getBoolean(InquiriesPDFSettingCodes.SHOW_QRCODE, Bundle.INQUIRIES_PDF, InquiriesPDFDefaultSettings.SHOW_QRCODE)) {
 			Iterator<ProbandListEntryOutVO> listEntryIt = listEntryVOs.iterator();
 			while (listEntryIt.hasNext()) {
 				putQRCodeImage(listEntryIt.next(), doc);

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/InquiriesPDFSettingCodes.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/InquiriesPDFSettingCodes.java
@@ -85,6 +85,7 @@ public interface InquiriesPDFSettingCodes {
 	public static final String PAINTER_CLASS = "painter_class";
 	public static final String PAINTER_SOURCE_FILES = "painter_source_files";
 	public static final String DATE_TIME_USER_TIME_ZONE = "date_time_user_time_zone";
+	public static final String SHOW_QRCODE = "show_qrcode";
 	public static final String QRCODE_COLOR = "qrcode_color";
 	public static final String QRCODE_IMAGE_WIDTH = "qrcode_image_width";
 	public static final String QRCODE_IMAGE_HEIGHT = "qrcode_image_height";

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/ProbandLetterPDFDefaultSettings.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/ProbandLetterPDFDefaultSettings.java
@@ -29,6 +29,7 @@ public final class ProbandLetterPDFDefaultSettings {
 	public static final String PAINTER_CLASS = null;
 	public static final ArrayList<String> PAINTER_SOURCE_FILES = null;
 	public static final boolean DATE_USER_TIME_ZONE = true;
+	public static final boolean SHOW_QRCODE = true;
 	public static final float QRCODE_Y = PROBAND_ID_Y + 70.0f;
 	public static final Color QRCODE_COLOR = Color.BLACK;
 	public static final int QRCODE_IMAGE_WIDTH = 250;

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/ProbandLetterPDFPainter.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/ProbandLetterPDFPainter.java
@@ -139,7 +139,8 @@ public class ProbandLetterPDFPainter extends PDFPainterBase implements PDFOutput
 
 	@Override
 	public void loadImages(PDDocument doc) throws Exception {
-		if (probandVOs != null) {
+		if (probandVOs != null
+				&& Settings.getBoolean(ProbandLetterPDFSettingCodes.SHOW_QRCODE, Bundle.PROBAND_LETTER_PDF, ProbandLetterPDFDefaultSettings.SHOW_QRCODE)) {
 			Iterator<ProbandOutVO> probandIt = probandVOs.iterator();
 			while (probandIt.hasNext()) {
 				putQRCodeImage(probandIt.next(), doc);

--- a/core/src/main/java/org/phoenixctms/ctsms/pdf/ProbandLetterPDFSettingCodes.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/pdf/ProbandLetterPDFSettingCodes.java
@@ -29,6 +29,7 @@ public interface ProbandLetterPDFSettingCodes {
 	public static final String PAINTER_CLASS = "painter_class";
 	public static final String PAINTER_SOURCE_FILES = "painter_source_files";
 	public static final String DATE_USER_TIME_ZONE = "date_user_time_zone";
+	public static final String SHOW_QRCODE = "show_qrcode";
 	public static final String QRCODE_Y = "qrcode_y";
 	public static final String QRCODE_COLOR = "qrcode_color";
 	public static final String QRCODE_IMAGE_WIDTH = "qrcode_image_width";

--- a/core/src/main/resources/ctsms-inquiries-pdf-settings.properties
+++ b/core/src/main/resources/ctsms-inquiries-pdf-settings.properties
@@ -124,6 +124,7 @@ show_sketch_regions=false
 
 date_time_user_time_zone=true
 
+show_qrcode=true
 qrcode_color=BLACK
 qrcode_image_width=500
 qrcode_image_height=500

--- a/core/src/main/resources/ctsms-probandletter-pdf-settings.properties
+++ b/core/src/main/resources/ctsms-probandletter-pdf-settings.properties
@@ -43,6 +43,7 @@ text_color=BLACK
 #frame_color=BLACK
 
 proband_id_y=89.31
+show_qrcode=true
 qrcode_y=160.0
 
 qrcode_color=BLACK

--- a/core/src/main/resources/fieldCalculation.js
+++ b/core/src/main/resources/fieldCalculation.js
@@ -1733,7 +1733,26 @@ var FIELD_CALCULATION_OVERRIDE_CALCULATED_VALUES = true;
 		return true;
 	}
 
+	function _applyRestApiJwtFromArgs(args) {
+		var key = (typeof AJAX_REST_API_JWT !== 'undefined') ? AJAX_REST_API_JWT : 'restApiJwt';
+		if (args == null || !_testPropertyExists(args, key)) {
+			return;
+		}
+		var jwt = args[key];
+		if (jwt == null || jwt.length === 0) {
+			return;
+		}
+		if (typeof REST_API_JWT !== 'undefined') {
+			REST_API_JWT = jwt;
+		}
+		if (typeof RestApi !== 'undefined' && typeof RestApi.applySessionJwt === 'function') {
+			RestApi.applySessionJwt(jwt);
+		}
+	}
+
 	function handleInitInputFieldVariables(xhr, status, args) {
+
+		_applyRestApiJwtFromArgs(args);
 
 		if (_testFlag(args, AJAX_OPERATION_SUCCESS)) {
 			if (FIELD_CALCULATION_DEBUG_LEVEL >= 1) {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/ApplicationScopeBean.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/ApplicationScopeBean.java
@@ -592,6 +592,11 @@ public class ApplicationScopeBean {
 			if (ajaxKeepAliveJsCallbackArgs != null) {
 				requestContext.addCallbackParam(JSValues.AJAX_KEEP_ALIVE_JS_CALLBACK_ARGS.toString(), ajaxKeepAliveJsCallbackArgs);
 			}
+			// Renew-if-needed (or always when rest_api_jwt_reissue_on_ajax) and push to browser.
+			String restApiJwt = WebUtil.getRestApiJwt();
+			if (restApiJwt != null) {
+				requestContext.addCallbackParam(JSValues.AJAX_REST_API_JWT.toString(), restApiJwt);
+			}
 		}
 	}
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/ApplicationScopeBean.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/ApplicationScopeBean.java
@@ -593,10 +593,7 @@ public class ApplicationScopeBean {
 				requestContext.addCallbackParam(JSValues.AJAX_KEEP_ALIVE_JS_CALLBACK_ARGS.toString(), ajaxKeepAliveJsCallbackArgs);
 			}
 			// Renew-if-needed (or always when rest_api_jwt_reissue_on_ajax) and push to browser.
-			String restApiJwt = WebUtil.getRestApiJwt();
-			if (restApiJwt != null) {
-				requestContext.addCallbackParam(JSValues.AJAX_REST_API_JWT.toString(), restApiJwt);
-			}
+			WebUtil.appendRestApiJwtCallbackParam(requestContext);
 		}
 	}
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/ApplicationScopeBean.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/ApplicationScopeBean.java
@@ -592,7 +592,7 @@ public class ApplicationScopeBean {
 			if (ajaxKeepAliveJsCallbackArgs != null) {
 				requestContext.addCallbackParam(JSValues.AJAX_KEEP_ALIVE_JS_CALLBACK_ARGS.toString(), ajaxKeepAliveJsCallbackArgs);
 			}
-			// Renew-if-needed (or always when rest_api_jwt_reissue_on_ajax) and push to browser.
+			// Renew-if-needed (or always when rest_api_jwt_reissue_on_ajax); field-init uses forced reissue separately.
 			WebUtil.appendRestApiJwtCallbackParam(requestContext);
 		}
 	}

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/SessionScopeBean.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/SessionScopeBean.java
@@ -755,11 +755,32 @@ public class SessionScopeBean implements FilterItemsStore {
 	}
 
 	public synchronized String getRestApiJwt() {
+		// RestApi-related AJAX (e.g. keep-alive): re-issue only if rest_api_jwt_reissue_on_ajax, else skew renew.
 		renewRestApiJwtIfRequired(true);
 		if (isLoggedIn() && logon != null) {
 			return logon.getJwt();
 		}
 		return null;
+	}
+
+	/**
+	 * Always re-issue RestApi JWT — page render and FieldCalculation handleInit (Signup issue_jwt parity).
+	 */
+	public synchronized String reissueRestApiJwt() {
+		if (!isLoggedIn() || logon == null || auth == null) {
+			return null;
+		}
+		try {
+			String jwt = WebUtil.getServiceLocator().getToolsService().issueJwt(auth, getRestApiJwtValidityPeriodSecs());
+			if (!CommonUtil.isEmptyString(jwt)) {
+				logon.setJwt(jwt);
+				auth.setJwt(jwt);
+			}
+		} catch (ServiceException | AuthorisationException | IllegalArgumentException e) {
+		} catch (AuthenticationException e) {
+			WebUtil.publishException(e);
+		}
+		return logon.getJwt();
 	}
 
 	public synchronized void renewRestApiJwtIfRequired() {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/SessionScopeBean.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/SessionScopeBean.java
@@ -755,7 +755,7 @@ public class SessionScopeBean implements FilterItemsStore {
 	}
 
 	public synchronized String getRestApiJwt() {
-		renewRestApiJwtIfRequired();
+		renewRestApiJwtIfRequired(true);
 		if (isLoggedIn() && logon != null) {
 			return logon.getJwt();
 		}
@@ -763,11 +763,16 @@ public class SessionScopeBean implements FilterItemsStore {
 	}
 
 	public synchronized void renewRestApiJwtIfRequired() {
+		renewRestApiJwtIfRequired(false);
+	}
+
+	private void renewRestApiJwtIfRequired(boolean allowAjaxForcedReissue) {
 		if (!isLoggedIn() || logon == null || auth == null) {
 			return;
 		}
-		boolean reissueOnAjax = Settings.getBoolean(SettingCodes.REST_API_JWT_REISSUE_ON_AJAX, Bundle.SETTINGS,
-				DefaultSettings.REST_API_JWT_REISSUE_ON_AJAX);
+		boolean reissueOnAjax = allowAjaxForcedReissue
+				&& Settings.getBoolean(SettingCodes.REST_API_JWT_REISSUE_ON_AJAX, Bundle.SETTINGS,
+						DefaultSettings.REST_API_JWT_REISSUE_ON_AJAX);
 		if (!reissueOnAjax && !isJwtExpiringSoon(logon.getJwt(),
 				Settings.getInt(SettingCodes.JWT_REFRESH_SKEW_SECS, Bundle.SETTINGS, DefaultSettings.JWT_REFRESH_SKEW_SECS))) {
 			return;

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/SessionScopeBean.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/SessionScopeBean.java
@@ -766,7 +766,9 @@ public class SessionScopeBean implements FilterItemsStore {
 		if (!isLoggedIn() || logon == null || auth == null) {
 			return;
 		}
-		if (!isJwtExpiringSoon(logon.getJwt(),
+		boolean reissueOnAjax = Settings.getBoolean(SettingCodes.REST_API_JWT_REISSUE_ON_AJAX, Bundle.SETTINGS,
+				DefaultSettings.REST_API_JWT_REISSUE_ON_AJAX);
+		if (!reissueOnAjax && !isJwtExpiringSoon(logon.getJwt(),
 				Settings.getInt(SettingCodes.JWT_REFRESH_SKEW_SECS, Bundle.SETTINGS, DefaultSettings.JWT_REFRESH_SKEW_SECS))) {
 			return;
 		}

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/EcrfFieldValueBean.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/EcrfFieldValueBean.java
@@ -372,6 +372,7 @@ public class EcrfFieldValueBean extends ManagedBeanBase {
 				//		JsUtil.encodeBase64(JsUtil.inputFieldVariableValueToJson(inquiryValues), false));
 				requestContext.addCallbackParam(JSValues.AJAX_INPUT_FIELD_ACTIVE_USER_BASE64.toString(),
 						JsUtil.encodeBase64(JsUtil.voToJson(WebUtil.getUser()), false));
+				WebUtil.appendRestApiJwtCallbackParam(requestContext);
 			}
 		}
 	}

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/EcrfFieldValueBean.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/EcrfFieldValueBean.java
@@ -373,7 +373,7 @@ public class EcrfFieldValueBean extends ManagedBeanBase {
 				requestContext.addCallbackParam(JSValues.AJAX_INPUT_FIELD_ACTIVE_USER_BASE64.toString(),
 						JsUtil.encodeBase64(JsUtil.voToJson(WebUtil.getUser()), false));
 			}
-			WebUtil.appendRestApiJwtCallbackParam(requestContext);
+			WebUtil.appendRestApiJwtCallbackParam(requestContext, true);
 		}
 	}
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/EcrfFieldValueBean.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/EcrfFieldValueBean.java
@@ -372,8 +372,8 @@ public class EcrfFieldValueBean extends ManagedBeanBase {
 				//		JsUtil.encodeBase64(JsUtil.inputFieldVariableValueToJson(inquiryValues), false));
 				requestContext.addCallbackParam(JSValues.AJAX_INPUT_FIELD_ACTIVE_USER_BASE64.toString(),
 						JsUtil.encodeBase64(JsUtil.voToJson(WebUtil.getUser()), false));
-				WebUtil.appendRestApiJwtCallbackParam(requestContext);
 			}
+			WebUtil.appendRestApiJwtCallbackParam(requestContext);
 		}
 	}
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/InquiryValueBeanBase.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/InquiryValueBeanBase.java
@@ -207,8 +207,8 @@ public abstract class InquiryValueBeanBase extends ManagedBeanBase {
 				requestContext.addCallbackParam(JSValues.AJAX_INPUT_FIELD_PROBAND_ADDRESSES_BASE64.toString(), JsUtil.encodeBase64(JsUtil.voToJson(getProbandAddresses()), false));
 				requestContext.addCallbackParam(JSValues.AJAX_INPUT_FIELD_ACTIVE_USER_BASE64.toString(),
 						JsUtil.encodeBase64(JsUtil.voToJson(WebUtil.getUser()), false));
-				WebUtil.appendRestApiJwtCallbackParam(requestContext);
 			}
+			WebUtil.appendRestApiJwtCallbackParam(requestContext);
 		}
 	}
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/InquiryValueBeanBase.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/InquiryValueBeanBase.java
@@ -208,7 +208,7 @@ public abstract class InquiryValueBeanBase extends ManagedBeanBase {
 				requestContext.addCallbackParam(JSValues.AJAX_INPUT_FIELD_ACTIVE_USER_BASE64.toString(),
 						JsUtil.encodeBase64(JsUtil.voToJson(WebUtil.getUser()), false));
 			}
-			WebUtil.appendRestApiJwtCallbackParam(requestContext);
+			WebUtil.appendRestApiJwtCallbackParam(requestContext, true);
 		}
 	}
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/InquiryValueBeanBase.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/InquiryValueBeanBase.java
@@ -207,6 +207,7 @@ public abstract class InquiryValueBeanBase extends ManagedBeanBase {
 				requestContext.addCallbackParam(JSValues.AJAX_INPUT_FIELD_PROBAND_ADDRESSES_BASE64.toString(), JsUtil.encodeBase64(JsUtil.voToJson(getProbandAddresses()), false));
 				requestContext.addCallbackParam(JSValues.AJAX_INPUT_FIELD_ACTIVE_USER_BASE64.toString(),
 						JsUtil.encodeBase64(JsUtil.voToJson(WebUtil.getUser()), false));
+				WebUtil.appendRestApiJwtCallbackParam(requestContext);
 			}
 		}
 	}

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/ProbandListEntryTagValueBean.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/ProbandListEntryTagValueBean.java
@@ -246,6 +246,7 @@ public class ProbandListEntryTagValueBean extends ManagedBeanBase {
 						JsUtil.encodeBase64(JsUtil.inputFieldVariableValueToJson(inquiryValues), false));
 				requestContext.addCallbackParam(JSValues.AJAX_INPUT_FIELD_ACTIVE_USER_BASE64.toString(),
 						JsUtil.encodeBase64(JsUtil.voToJson(WebUtil.getUser()), false));
+				WebUtil.appendRestApiJwtCallbackParam(requestContext);
 			}
 		}
 	}

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/ProbandListEntryTagValueBean.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/ProbandListEntryTagValueBean.java
@@ -246,8 +246,8 @@ public class ProbandListEntryTagValueBean extends ManagedBeanBase {
 						JsUtil.encodeBase64(JsUtil.inputFieldVariableValueToJson(inquiryValues), false));
 				requestContext.addCallbackParam(JSValues.AJAX_INPUT_FIELD_ACTIVE_USER_BASE64.toString(),
 						JsUtil.encodeBase64(JsUtil.voToJson(WebUtil.getUser()), false));
-				WebUtil.appendRestApiJwtCallbackParam(requestContext);
 			}
+			WebUtil.appendRestApiJwtCallbackParam(requestContext);
 		}
 	}
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/ProbandListEntryTagValueBean.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/model/shared/ProbandListEntryTagValueBean.java
@@ -247,7 +247,7 @@ public class ProbandListEntryTagValueBean extends ManagedBeanBase {
 				requestContext.addCallbackParam(JSValues.AJAX_INPUT_FIELD_ACTIVE_USER_BASE64.toString(),
 						JsUtil.encodeBase64(JsUtil.voToJson(WebUtil.getUser()), false));
 			}
-			WebUtil.appendRestApiJwtCallbackParam(requestContext);
+			WebUtil.appendRestApiJwtCallbackParam(requestContext, true);
 		}
 	}
 

--- a/web/src/main/java/org/phoenixctms/ctsms/web/util/DefaultSettings.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/util/DefaultSettings.java
@@ -40,6 +40,7 @@ public final class DefaultSettings {
 	public final static int SESSION_TIMEOUT = 60;
 	public final static int SESSION_TIMEOUT_TRUSTED = 60;
 	public final static int JWT_REFRESH_SKEW_SECS = 55;
+	public final static boolean REST_API_JWT_REISSUE_ON_AJAX = false;
 	public final static String META_DESCRIPTION = "{0}";
 	public final static String CONTACT_EMAIL = "nobody@{0}";
 	public final static String BANNER_IMAGE_URL = "https://www.phoenixctms.org/analytics.php";

--- a/web/src/main/java/org/phoenixctms/ctsms/web/util/JSValues.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/util/JSValues.java
@@ -504,7 +504,8 @@ public enum JSValues {
 			case REST_API_URL:
 				return ((HttpServletRequest) FacesContext.getCurrentInstance().getExternalContext().getRequest()).getContextPath() + "/" + WebUtil.REST_API_PATH + "/";
 			case REST_API_JWT:
-				String restApiJwt = WebUtil.getRestApiJwt();
+				// Page render: always re-issue (Signup get_template / issue_jwt parity).
+				String restApiJwt = WebUtil.reissueRestApiJwt();
 				if (restApiJwt != null) {
 					return restApiJwt;
 				}

--- a/web/src/main/java/org/phoenixctms/ctsms/web/util/JSValues.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/util/JSValues.java
@@ -358,6 +358,7 @@ public enum JSValues {
 	REST_API_URL(""),
 	REST_API_JWT(""),
 	JWT_REFRESH_SKEW_SECS(""),
+	AJAX_REST_API_JWT("restApiJwt"),
 	// multiple window navigation:
 	INVENTORY_ENTITY_WINDOW_NAME("inventory"),
 	STAFF_ENTITY_WINDOW_NAME("staff"),

--- a/web/src/main/java/org/phoenixctms/ctsms/web/util/SettingCodes.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/util/SettingCodes.java
@@ -18,6 +18,7 @@ public interface SettingCodes {
 	public final static String SESSION_TIMEOUT = "session_timeout";
 	public final static String SESSION_TIMEOUT_TRUSTED = "session_timeout_trusted";
 	public final static String JWT_REFRESH_SKEW_SECS = "jwt_refresh_skew_secs";
+	public final static String REST_API_JWT_REISSUE_ON_AJAX = "rest_api_jwt_reissue_on_ajax";
 	public final static String CONTACT_EMAIL = "contact_email";
 	public final static String META_DESCRIPTION = "meta_description";
 	public final static String BANNER_IMAGE_URL = "banner_image_url";

--- a/web/src/main/java/org/phoenixctms/ctsms/web/util/WebUtil.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/util/WebUtil.java
@@ -176,18 +176,33 @@ public final class WebUtil {
 	}
 
 	/**
-	 * Renew RestApi JWT if near expiry (or always when rest_api_jwt_reissue_on_ajax)
-	 * and push it as a PrimeFaces callback param for browser RestApi clients.
+	 * Push RestApi JWT as a PrimeFaces callback param.
+	 * Keep-alive / general AJAX: skew renew, or always re-issue when rest_api_jwt_reissue_on_ajax (Signup json_response).
 	 */
 	public static void appendRestApiJwtCallbackParam(RequestContext context) {
+		appendRestApiJwtCallbackParam(context, false);
+	}
+
+	/**
+	 * @param forFieldInit when true (FieldCalculation handleInit), always re-issue; when false, AJAX policy via getRestApiJwt.
+	 */
+	public static void appendRestApiJwtCallbackParam(RequestContext context, boolean forFieldInit) {
 		RequestContext requestContext = context == null ? RequestContext.getCurrentInstance() : context;
 		if (requestContext == null) {
 			return;
 		}
-		String restApiJwt = getRestApiJwt();
+		String restApiJwt = forFieldInit ? reissueRestApiJwt() : getRestApiJwt();
 		if (restApiJwt != null) {
 			requestContext.addCallbackParam(JSValues.AJAX_REST_API_JWT.toString(), restApiJwt);
 		}
+	}
+
+	public static String reissueRestApiJwt() {
+		SessionScopeBean sessionScopeBean = getSessionScopeBean();
+		if (sessionScopeBean != null) {
+			return sessionScopeBean.reissueRestApiJwt();
+		}
+		return null;
 	}
 
 	public static String beautifyJson(String json) {

--- a/web/src/main/java/org/phoenixctms/ctsms/web/util/WebUtil.java
+++ b/web/src/main/java/org/phoenixctms/ctsms/web/util/WebUtil.java
@@ -175,6 +175,21 @@ public final class WebUtil {
 		return requestContext;
 	}
 
+	/**
+	 * Renew RestApi JWT if near expiry (or always when rest_api_jwt_reissue_on_ajax)
+	 * and push it as a PrimeFaces callback param for browser RestApi clients.
+	 */
+	public static void appendRestApiJwtCallbackParam(RequestContext context) {
+		RequestContext requestContext = context == null ? RequestContext.getCurrentInstance() : context;
+		if (requestContext == null) {
+			return;
+		}
+		String restApiJwt = getRestApiJwt();
+		if (restApiJwt != null) {
+			requestContext.addCallbackParam(JSValues.AJAX_REST_API_JWT.toString(), restApiJwt);
+		}
+	}
+
 	public static String beautifyJson(String json) {
 		try {
 			JsonElement je = JSON_PARSER.parse(json);

--- a/web/src/main/resources/org/phoenixctms/ctsms/web/settings.properties
+++ b/web/src/main/resources/org/phoenixctms/ctsms/web/settings.properties
@@ -27,6 +27,7 @@ validation_reports_url=https://phoenixctms.org/wp-content/uploads/downloads/vali
 session_timeout=10
 session_timeout_trusted=180
 jwt_refresh_skew_secs=55
+rest_api_jwt_reissue_on_ajax=false
 
 api_title=${application.abbreviation} REST API
 api_version=${application.version}

--- a/web/src/main/resources/org/phoenixctms/ctsms/web/settings.properties
+++ b/web/src/main/resources/org/phoenixctms/ctsms/web/settings.properties
@@ -27,7 +27,8 @@ validation_reports_url=https://phoenixctms.org/wp-content/uploads/downloads/vali
 session_timeout=10
 session_timeout_trusted=180
 jwt_refresh_skew_secs=55
-# When true, reissue RestApi JWT on each keep-alive and field-init AJAX (Signup json_response parity). Default: skew renew only.
+# When true, re-issue RestApi JWT on each RestApi-related AJAX (keep-alive; Signup json_response parity).
+# FieldCalculation handleInit and full page render always re-issue regardless. Default: skew renew on AJAX only.
 rest_api_jwt_reissue_on_ajax=false
 
 api_title=${application.abbreviation} REST API

--- a/web/src/main/resources/org/phoenixctms/ctsms/web/settings.properties
+++ b/web/src/main/resources/org/phoenixctms/ctsms/web/settings.properties
@@ -27,6 +27,7 @@ validation_reports_url=https://phoenixctms.org/wp-content/uploads/downloads/vali
 session_timeout=10
 session_timeout_trusted=180
 jwt_refresh_skew_secs=55
+# When true, reissue RestApi JWT on each keep-alive and field-init AJAX (Signup json_response parity). Default: skew renew only.
 rest_api_jwt_reissue_on_ajax=false
 
 api_title=${application.abbreviation} REST API

--- a/web/src/main/webapp/resources/js/common.js
+++ b/web/src/main/webapp/resources/js/common.js
@@ -221,18 +221,20 @@ function handleReload(xhr, status, args) {
 
 function handleKeepAliveCallback(xhr, status, args) {
 
-	if (_testFlag(args, AJAX_OPERATION_SUCCESS) && _testPropertyExists(args, AJAX_KEEP_ALIVE_JS_CALLBACK)) {
-		var ajaxKeepAliveJsCallback = args[AJAX_KEEP_ALIVE_JS_CALLBACK];
-		if (_testFunction(window[ajaxKeepAliveJsCallback])) {
-			if (_testPropertyExists(args, AJAX_KEEP_ALIVE_JS_CALLBACK_ARGS)) {
-				var ajaxKeepAliveJsCallbackArgs = JSON.parse(args[AJAX_KEEP_ALIVE_JS_CALLBACK_ARGS]);
-				window[ajaxKeepAliveJsCallback](ajaxKeepAliveJsCallbackArgs);
-			} else {
-				window[ajaxKeepAliveJsCallback]();
+	if (_testFlag(args, AJAX_OPERATION_SUCCESS)) {
+		applyRestApiJwtFromKeepAlive(args);
+		if (_testPropertyExists(args, AJAX_KEEP_ALIVE_JS_CALLBACK)) {
+			var ajaxKeepAliveJsCallback = args[AJAX_KEEP_ALIVE_JS_CALLBACK];
+			if (_testFunction(window[ajaxKeepAliveJsCallback])) {
+				if (_testPropertyExists(args, AJAX_KEEP_ALIVE_JS_CALLBACK_ARGS)) {
+					var ajaxKeepAliveJsCallbackArgs = JSON.parse(args[AJAX_KEEP_ALIVE_JS_CALLBACK_ARGS]);
+					window[ajaxKeepAliveJsCallback](ajaxKeepAliveJsCallbackArgs);
+				} else {
+					window[ajaxKeepAliveJsCallback]();
+				}
 			}
 		}
 	}
-	applyRestApiJwtFromKeepAlive(args);
 
 }
 

--- a/web/src/main/webapp/resources/js/common.js
+++ b/web/src/main/webapp/resources/js/common.js
@@ -222,7 +222,7 @@ function handleReload(xhr, status, args) {
 function handleKeepAliveCallback(xhr, status, args) {
 
 	if (_testFlag(args, AJAX_OPERATION_SUCCESS)) {
-		applyRestApiJwtFromKeepAlive(args);
+		applyRestApiJwtFromArgs(args);
 		if (_testPropertyExists(args, AJAX_KEEP_ALIVE_JS_CALLBACK)) {
 			var ajaxKeepAliveJsCallback = args[AJAX_KEEP_ALIVE_JS_CALLBACK];
 			if (_testFunction(window[ajaxKeepAliveJsCallback])) {
@@ -238,7 +238,7 @@ function handleKeepAliveCallback(xhr, status, args) {
 
 }
 
-function applyRestApiJwtFromKeepAlive(args) {
+function applyRestApiJwtFromArgs(args) {
 	if (args == null || !_testPropertyExists(args, AJAX_REST_API_JWT)) {
 		return;
 	}

--- a/web/src/main/webapp/resources/js/common.js
+++ b/web/src/main/webapp/resources/js/common.js
@@ -232,7 +232,24 @@ function handleKeepAliveCallback(xhr, status, args) {
 			}
 		}
 	}
+	applyRestApiJwtFromKeepAlive(args);
 
+}
+
+function applyRestApiJwtFromKeepAlive(args) {
+	if (args == null || !_testPropertyExists(args, AJAX_REST_API_JWT)) {
+		return;
+	}
+	var jwt = args[AJAX_REST_API_JWT];
+	if (jwt == null || jwt.length === 0) {
+		return;
+	}
+	if (typeof REST_API_JWT !== 'undefined') {
+		REST_API_JWT = jwt;
+	}
+	if (typeof RestApi !== 'undefined' && typeof RestApi.applySessionJwt === 'function') {
+		RestApi.applySessionJwt(jwt);
+	}
 }
 
 function keepAliveExec(functionName, args) {

--- a/web/src/main/webapp/resources/js/fieldCalculation.js
+++ b/web/src/main/webapp/resources/js/fieldCalculation.js
@@ -1733,7 +1733,26 @@ var FIELD_CALCULATION_OVERRIDE_CALCULATED_VALUES = true;
 		return true;
 	}
 
+	function _applyRestApiJwtFromArgs(args) {
+		var key = (typeof AJAX_REST_API_JWT !== 'undefined') ? AJAX_REST_API_JWT : 'restApiJwt';
+		if (args == null || !_testPropertyExists(args, key)) {
+			return;
+		}
+		var jwt = args[key];
+		if (jwt == null || jwt.length === 0) {
+			return;
+		}
+		if (typeof REST_API_JWT !== 'undefined') {
+			REST_API_JWT = jwt;
+		}
+		if (typeof RestApi !== 'undefined' && typeof RestApi.applySessionJwt === 'function') {
+			RestApi.applySessionJwt(jwt);
+		}
+	}
+
 	function handleInitInputFieldVariables(xhr, status, args) {
+
+		_applyRestApiJwtFromArgs(args);
 
 		if (_testFlag(args, AJAX_OPERATION_SUCCESS)) {
 			if (FIELD_CALCULATION_DEBUG_LEVEL >= 1) {

--- a/web/src/main/webapp/resources/js/restApi.js
+++ b/web/src/main/webapp/resources/js/restApi.js
@@ -109,6 +109,7 @@ var RestApi = RestApi || {};
 	}
 
 	function applySessionJwt(jwt) {
+		var previousJwt = sessionJwt;
 		sessionJwt = jwt;
 		if (typeof REST_API_JWT !== 'undefined') {
 			REST_API_JWT = jwt;
@@ -121,6 +122,10 @@ var RestApi = RestApi || {};
 			}
 		} else {
 			sessionJwtExpires = null;
+		}
+		if (jwt != null && jwt.length > 0 && jwt !== previousJwt) {
+			var expLabel = (claims != null && claims.exp != null) ? (' exp=' + claims.exp) : '';
+			console.log('RestApi session JWT applied' + expLabel);
 		}
 	}
 

--- a/web/src/main/webapp/resources/js/restApi.js
+++ b/web/src/main/webapp/resources/js/restApi.js
@@ -485,6 +485,7 @@ var RestApi = RestApi || {};
 	RestApi.debounceIsCurrent = debounceIsCurrent;
 	RestApi.trackRequest = trackRequest;
 	RestApi.abortRequest = abortRequest;
+	RestApi.applySessionJwt = applySessionJwt;
 
 	if (debug_level >= 1) {
 		console.log("rest api utilities loaded");


### PR DESCRIPTION
## Summary
- Adds `rest_api_jwt_reissue_on_ajax` (default `false`) mirroring Signup's opt-in always-reissue behavior.
- When enabled, `renewRestApiJwtIfRequired` skips the skew window and re-issues on each renew call.
- Session keep-alive now returns the (renewed) JWT via `restApiJwt` callback param; `common.js` applies it to `REST_API_JWT` / `RestApi.applySessionJwt`.

## Test plan
- [ ] With default `false`, keep-alive still works; JWT only rotates near `jwt_refresh_skew_secs`.
- [ ] Set `rest_api_jwt_reissue_on_ajax=true`; trigger keep-alive and confirm callback includes a fresh JWT with full session timeout lifetime.
- [ ] Field-calculation RestApi calls continue to work after keep-alive updates the browser token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keep-alive activity, AJAX requests, and field initialization can refresh REST API session tokens automatically.
  * Added a setting to enable or disable token renewal during AJAX requests; disabled by default.
  * QR codes are included in inquiry and proband letter PDFs by default, with configurable display settings.
* **Bug Fixes**
  * Improved session continuity by applying refreshed authentication tokens during web interactions.
  * Prevented unnecessary token-expiration checks when AJAX-based renewal is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->