### PR TITLE
Filter datatable department columns by name instead of ID dropdowns.

### DIFF
--- a/core/src/main/java/org/phoenixctms/ctsms/query/CriteriaUtil.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/query/CriteriaUtil.java
@@ -209,7 +209,7 @@ public final class CriteriaUtil {
 				&& filterFieldAssociationPath.getPathDepth() > 0) {
 			AssociationPath parentPath = filterFieldAssociationPath.dropLast();
 			if (parentPath.isValid()) {
-				criteriaMap.createCriteria(parentPath);
+				criteriaMap.createCriteria(parentPath.getFullQualifiedPropertyName());
 				Class parentClass = criteriaMap.getPropertyClassMap().get(parentPath.getFullQualifiedPropertyName());
 				if (parentClass != null && Department.class.equals(parentClass)) {
 					return parentPath.append(DEPARTMENT_NAME_L10N_KEY_PROPERTY);

--- a/core/src/main/java/org/phoenixctms/ctsms/query/CriteriaUtil.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/query/CriteriaUtil.java
@@ -209,14 +209,28 @@ public final class CriteriaUtil {
 				&& filterFieldAssociationPath.getPathDepth() > 0) {
 			AssociationPath parentPath = filterFieldAssociationPath.dropLast();
 			if (parentPath.isValid()) {
-				criteriaMap.createCriteria(parentPath.getFullQualifiedPropertyName());
-				Class parentClass = criteriaMap.getPropertyClassMap().get(parentPath.getFullQualifiedPropertyName());
-				if (parentClass != null && Department.class.equals(parentClass)) {
-					return parentPath.append(DEPARTMENT_NAME_L10N_KEY_PROPERTY);
+				try {
+					Class parentClass = resolveAssociationClass(criteriaMap.getEntity(), parentPath);
+					if (parentClass != null && Department.class.equals(parentClass)) {
+						return parentPath.append(DEPARTMENT_NAME_L10N_KEY_PROPERTY);
+					}
+				} catch (IllegalArgumentException e) {
 				}
 			}
 		}
 		return filterFieldAssociationPath;
+	}
+
+	private static Class resolveAssociationClass(Class entity, AssociationPath path) {
+		if (entity == null || path == null || !path.isValid()) {
+			return null;
+		}
+		Class propertyClass = entity;
+		ArrayList<String> fullPath = path.getFullPath();
+		for (int i = 0; i < fullPath.size(); i++) {
+			propertyClass = CoreUtil.getPropertyClass(propertyClass, fullPath.get(i));
+		}
+		return propertyClass;
 	}
 
 	private static org.hibernate.criterion.Criterion getAliasVariantsCriterion(String value) {

--- a/core/src/main/java/org/phoenixctms/ctsms/query/CriteriaUtil.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/query/CriteriaUtil.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Method;
 import java.sql.Timestamp;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -34,6 +35,7 @@ import org.hibernate.type.EntityType;
 import org.hibernate.type.Type;
 import org.phoenixctms.ctsms.adapt.ExpirationEntityAdapter;
 import org.phoenixctms.ctsms.adapt.ReminderEntityAdapter;
+import org.phoenixctms.ctsms.domain.Department;
 import org.phoenixctms.ctsms.domain.LecturerImpl;
 import org.phoenixctms.ctsms.domain.Staff;
 import org.phoenixctms.ctsms.domain.TeamMemberImpl;
@@ -102,6 +104,9 @@ public final class CriteriaUtil {
 	private final static String ALTERNATIVE_FILTER_FIRST_NAME_VARIANTS = "firstNameVariants";
 	private final static String ALTERNATIVE_FILTER_LAST_NAME_VARIANTS = "lastNameVariants";
 	private final static String ALTERNATIVE_FILTER_ALIAS_VARIANTS = "aliasVariants";
+	private final static String ALTERNATIVE_FILTER_DEPARTMENT_NAME = "departmentName";
+	private final static String DEPARTMENT_NAME_PROPERTY = "name";
+	private final static String DEPARTMENT_NAME_L10N_KEY_PROPERTY = "nameL10nKey";
 	private final static HashMap<String, String[]> ALTERNATIVE_FILTER_MAP = new HashMap<String, String[]>();
 	static {
 		ALTERNATIVE_FILTER_MAP.put("ProbandContactParticulars.lastNameHash",
@@ -109,6 +114,7 @@ public final class CriteriaUtil {
 		ALTERNATIVE_FILTER_MAP.put("PersonContactParticulars.lastName",
 				new String[] { "firstName", ALTERNATIVE_FILTER_FIRST_NAME_VARIANTS, ALTERNATIVE_FILTER_LAST_NAME_VARIANTS });
 		ALTERNATIVE_FILTER_MAP.put("AnimalContactParticulars.animalName", new String[] { "alias" });
+		ALTERNATIVE_FILTER_MAP.put("Department.nameL10nKey", new String[] { ALTERNATIVE_FILTER_DEPARTMENT_NAME });
 	}
 	private final static String UNSUPPORTED_BINARY_RESTRICTION_CRITERION_TYPE = "unsupported binary restriction criterion type {0}";
 	private final static String UNSUPPORTED_UNARY_RESTRICTION_CRITERION_TYPE = "unsupported unary restriction criterion type {0}";
@@ -173,6 +179,8 @@ public final class CriteriaUtil {
 						}
 					} else if (ALTERNATIVE_FILTER_ALIAS_VARIANTS.equals(altFilter)) {
 						or = applyOr(getAliasVariantsCriterion(value), or);
+					} else if (ALTERNATIVE_FILTER_DEPARTMENT_NAME.equals(altFilter)) {
+						or = applyOr(getDepartmentNameCriterion(value), or);
 					} else {
 						AssociationPath altFilterFieldAssociationPath = new AssociationPath(
 								filterFieldAssociationPath.getPathString() + AssociationPath.ASSOCIATION_PATH_SEPARATOR + altFilter);
@@ -185,6 +193,30 @@ public final class CriteriaUtil {
 			}
 		}
 		return null;
+	}
+
+	private static org.hibernate.criterion.Criterion getDepartmentNameCriterion(String value) {
+		Collection<String> matchingKeys = L10nUtil.getMatchingDepartmentNameL10nKeys(value);
+		if (matchingKeys != null && matchingKeys.size() > 0) {
+			return Restrictions.in(DEPARTMENT_NAME_L10N_KEY_PROPERTY, matchingKeys);
+		}
+		return null;
+	}
+
+	private static AssociationPath rewriteDepartmentNameFilter(SubCriteriaMap criteriaMap, AssociationPath filterFieldAssociationPath) {
+		if (criteriaMap != null && filterFieldAssociationPath != null && filterFieldAssociationPath.isValid()
+				&& DEPARTMENT_NAME_PROPERTY.equals(filterFieldAssociationPath.getPropertyName())
+				&& filterFieldAssociationPath.getPathDepth() > 0) {
+			AssociationPath parentPath = filterFieldAssociationPath.dropLast();
+			if (parentPath.isValid()) {
+				criteriaMap.createCriteria(parentPath);
+				Class parentClass = criteriaMap.getPropertyClassMap().get(parentPath.getFullQualifiedPropertyName());
+				if (parentClass != null && Department.class.equals(parentClass)) {
+					return parentPath.append(DEPARTMENT_NAME_L10N_KEY_PROPERTY);
+				}
+			}
+		}
+		return filterFieldAssociationPath;
 	}
 
 	private static org.hibernate.criterion.Criterion getAliasVariantsCriterion(String value) {
@@ -727,6 +759,7 @@ public final class CriteriaUtil {
 							continue;
 						}
 						AssociationPath filterFieldAssociationPath = new AssociationPath(filter.getKey());
+						filterFieldAssociationPath = rewriteDepartmentNameFilter(criteriaMap, filterFieldAssociationPath);
 						Criteria subCriteria;
 						if (distinct && sortJoin) {
 							AssociationPath path = filterFieldAssociationPath;
@@ -1191,6 +1224,7 @@ public final class CriteriaUtil {
 							continue;
 						}
 						AssociationPath filterFieldAssociationPath = new AssociationPath(filter.getKey());
+						filterFieldAssociationPath = rewriteDepartmentNameFilter(criteriaMap, filterFieldAssociationPath);
 						Criteria subCriteria;
 						if (sortFieldAssociationPath.isValid()
 								&& sortFieldAssociationPath.getPathDepth() >= 1

--- a/core/src/main/java/org/phoenixctms/ctsms/query/QueryUtil.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/query/QueryUtil.java
@@ -35,6 +35,7 @@ import org.phoenixctms.ctsms.domain.CriterionRestriction;
 import org.phoenixctms.ctsms.domain.CriterionRestrictionDao;
 import org.phoenixctms.ctsms.domain.CriterionTie;
 import org.phoenixctms.ctsms.domain.CriterionTieDao;
+import org.phoenixctms.ctsms.domain.Department;
 import org.phoenixctms.ctsms.domain.InputFieldImpl;
 import org.phoenixctms.ctsms.domain.InventoryImpl;
 import org.phoenixctms.ctsms.domain.MassMailImpl;
@@ -105,6 +106,9 @@ public final class QueryUtil {
 	private final static String ALTERNATIVE_FILTER_FIRST_NAME_VARIANTS = "firstNameVariants";
 	private final static String ALTERNATIVE_FILTER_LAST_NAME_VARIANTS = "lastNameVariants";
 	private final static String ALTERNATIVE_FILTER_ALIAS_VARIANTS = "aliasVariants";
+	private final static String ALTERNATIVE_FILTER_DEPARTMENT_NAME = "departmentName";
+	private final static String DEPARTMENT_NAME_PROPERTY = "name";
+	private final static String DEPARTMENT_NAME_L10N_KEY_PROPERTY = "nameL10nKey";
 	private final static HashMap<String, String[]> ALTERNATIVE_FILTER_MAP = new HashMap<String, String[]>();
 	private final static HashMap<String, ArrayList<StaticCriterionTerm>> FIXED_CRITERION_TERMS_MAP = new HashMap<String, ArrayList<StaticCriterionTerm>>();
 	static {
@@ -113,6 +117,7 @@ public final class QueryUtil {
 		ALTERNATIVE_FILTER_MAP.put("PersonContactParticulars.lastName",
 				new String[] { "firstName", ALTERNATIVE_FILTER_FIRST_NAME_VARIANTS, ALTERNATIVE_FILTER_LAST_NAME_VARIANTS });
 		ALTERNATIVE_FILTER_MAP.put("AnimalContactParticulars.animalName", new String[] { "alias" });
+		ALTERNATIVE_FILTER_MAP.put("Department.nameL10nKey", new String[] { ALTERNATIVE_FILTER_DEPARTMENT_NAME });
 		addPropertyCriterionTerms("proband.diagnoses.code.systematics.blocks",
 				"proband.diagnoses.code.systematics.blocks.last", "{0} = ?",
 				new QueryParameterValue(true));
@@ -194,6 +199,23 @@ public final class QueryUtil {
 			throw new IllegalArgumentException(L10nUtil.getMessage(MessageCodes.INVALID_PROPERTY_ASSOCIATION_PATH, DefaultMessages.INVALID_PROPERTY_ASSOCIATION_PATH,
 					new Object[] { fullyQualifiedPropertyName.getPathString() }));
 		}
+	}
+
+	private static AssociationPath rewriteDepartmentNameFilter(Class entityClass, String entityName, AssociationPath filterFieldAssociationPath,
+			HashMap<String, AssociationPath> explicitJoinsMap, HashMap<String, Class> propertyClassMap) {
+		if (filterFieldAssociationPath != null && filterFieldAssociationPath.isValid()
+				&& DEPARTMENT_NAME_PROPERTY.equals(filterFieldAssociationPath.getPropertyName())
+				&& filterFieldAssociationPath.getPathDepth() > 0) {
+			AssociationPath parentPath = filterFieldAssociationPath.dropLast();
+			if (parentPath.isValid()) {
+				aliasPropertyName(entityClass, parentPath, entityName, explicitJoinsMap, propertyClassMap);
+				Class parentClass = propertyClassMap.get(parentPath.getFullQualifiedPropertyName());
+				if (parentClass != null && Department.class.equals(parentClass)) {
+					return parentPath.append(DEPARTMENT_NAME_L10N_KEY_PROPERTY);
+				}
+			}
+		}
+		return filterFieldAssociationPath;
 	}
 
 	private static void appendJoins(StringBuilder statement, HashMap<String, AssociationPath> explicitJoinsMap) {
@@ -306,6 +328,30 @@ public final class QueryUtil {
 							}
 							orHqlWhereClause.append(variantHql);
 							orQueryValues.addAll(variantQueryValues);
+						}
+					} else if (ALTERNATIVE_FILTER_DEPARTMENT_NAME.equals(altFilter)) {
+						AssociationPath variantPath = new AssociationPath(
+								filterFieldAssociationPath.getPathString() + AssociationPath.ASSOCIATION_PATH_SEPARATOR + DEPARTMENT_NAME_L10N_KEY_PROPERTY);
+						String variantPropertyName = aliasPropertyName(entityClass, variantPath, entityName, explicitJoinsMap, propertyClassMap);
+						Collection<String> matchingKeys = L10nUtil.getMatchingDepartmentNameL10nKeys(value);
+						if (matchingKeys != null && matchingKeys.size() > 0) {
+							if (orHqlWhereClause.length() > 0) {
+								orHqlWhereClause.append(" or ");
+							}
+							orHqlWhereClause.append(variantPropertyName);
+							orHqlWhereClause.append(" in (");
+							boolean first = true;
+							Iterator<String> matchingKeyIt = matchingKeys.iterator();
+							while (matchingKeyIt.hasNext()) {
+								if (first) {
+									first = false;
+								} else {
+									orHqlWhereClause.append(", ");
+								}
+								orHqlWhereClause.append("?");
+								orQueryValues.add(new QueryParameterValue(String.class, matchingKeyIt.next()));
+							}
+							orHqlWhereClause.append(")");
 						}
 					} else {
 						AssociationPath altFilterFieldAssociationPath = new AssociationPath(
@@ -1333,6 +1379,7 @@ public final class QueryUtil {
 				while (filterIt.hasNext()) {
 					Map.Entry<String, String> filter = filterIt.next();
 					AssociationPath filterFieldAssociationPath = new AssociationPath(filter.getKey());
+					filterFieldAssociationPath = rewriteDepartmentNameFilter(entityClass, entityName, filterFieldAssociationPath, explicitJoinsMap, propertyClassMap);
 					String filterField = aliasPropertyName(entityClass, filterFieldAssociationPath, entityName, explicitJoinsMap, propertyClassMap);
 					StringBuilder altOrHqlWhereClause = new StringBuilder();
 					ArrayList<QueryParameterValue> altOrQueryValues = new ArrayList<QueryParameterValue>();

--- a/core/src/main/java/org/phoenixctms/ctsms/service/shared/ToolsServiceImpl.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/service/shared/ToolsServiceImpl.java
@@ -1506,7 +1506,6 @@ public class ToolsServiceImpl
 			limit = Settings.getIntNullable(SettingCodes.DEPARTMENT_AUTOCOMPLETE_DEFAULT_RESULT_LIMIT, Bundle.SETTINGS,
 					DefaultSettings.DEPARTMENT_AUTOCOMPLETE_DEFAULT_RESULT_LIMIT);
 		}
-		String name = (nameInfix != null ? nameInfix.trim().toLowerCase() : null);
 		HashSet<Long> ids = new HashSet<Long>();
 		if (departmentIds != null) {
 			ids.addAll(departmentIds);
@@ -1520,7 +1519,7 @@ public class ToolsServiceImpl
 			DepartmentVO departmentVO = (DepartmentVO) it.next();
 			if ((limit == null || result.size() < limit)
 					&& (departmentVO.getVisible() || ids.contains(departmentVO.getId()))
-					&& (name == null || name.length() == 0 || departmentVO.getName().toLowerCase().contains(name) || departmentVO.getNameL10nKey().toLowerCase().contains(name))) {
+					&& L10nUtil.departmentNameMatches(departmentVO.getNameL10nKey(), departmentVO.getName(), nameInfix)) {
 				result.add(departmentVO);
 			}
 		}

--- a/core/src/main/java/org/phoenixctms/ctsms/util/L10nUtil.java
+++ b/core/src/main/java/org/phoenixctms/ctsms/util/L10nUtil.java
@@ -1,7 +1,10 @@
 package org.phoenixctms.ctsms.util;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.Locale;
+import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.TimeZone;
 
@@ -526,6 +529,34 @@ public final class L10nUtil {
 
 	public static String getDepartmentName(Locales locale, String l10nKey) {
 		return CommonUtil.getString(l10nKey, getBundle(locale, departmentsBundleBasename), DefaultMessages.DEPARTMENT_NAME);
+	}
+
+	public static boolean departmentNameMatches(String nameL10nKey, String translatedName, String nameInfix) {
+		String name = (nameInfix != null ? nameInfix.trim().toLowerCase() : null);
+		if (name == null || name.length() == 0) {
+			return true;
+		}
+		if (nameL10nKey != null && nameL10nKey.toLowerCase().contains(name)) {
+			return true;
+		}
+		return translatedName != null && translatedName.toLowerCase().contains(name);
+	}
+
+	public static Collection<String> getMatchingDepartmentNameL10nKeys(String nameInfix) {
+		ArrayList<String> matchingKeys = new ArrayList<String>();
+		String name = (nameInfix != null ? nameInfix.trim().toLowerCase() : null);
+		if (name == null || name.length() == 0) {
+			return matchingKeys;
+		}
+		Map<String, String> symbols = CommonUtil.getBundleSymbolMap(getBundle(Locales.USER, departmentsBundleBasename), false);
+		Iterator<Map.Entry<String, String>> it = symbols.entrySet().iterator();
+		while (it.hasNext()) {
+			Map.Entry<String, String> entry = it.next();
+			if (departmentNameMatches(entry.getKey(), entry.getValue(), nameInfix)) {
+				matchingKeys.add(entry.getKey());
+			}
+		}
+		return matchingKeys;
 	}
 
 	public static String getEcrfFieldStatusTypeName(Locales locale, String l10nKey) {

--- a/core/src/test/java/org/phoenixctms/ctsms/selenium/trial/EcrfDataEntryTest.java
+++ b/core/src/test/java/org/phoenixctms/ctsms/selenium/trial/EcrfDataEntryTest.java
@@ -49,6 +49,7 @@ public class EcrfDataEntryTest extends SeleniumTestBase implements ProcessorJobO
 	private Long probandId;
 	private XlsImporter xlsImporter;
 	private final static Pattern FILE_NAME_ID_REGEXP = Pattern.compile("'([0-9a-z._-]+)' \\(file ID (\\d+)\\)");
+	private final static long FILE_DOWNLOAD_TIMEOUT_MS = 60_000L;
 	private String exportFile;
 	private Connection connection;
 
@@ -158,6 +159,7 @@ public class EcrfDataEntryTest extends SeleniumTestBase implements ProcessorJobO
 
 	@Test(description = "Execute trial job for exporting eCRF data as SQLite database.")
 	public void test_06_export_ecrf_data_job() throws Throwable {
+		setSkipScreenshot(true);
 		clickTab("tabView:trialjobs");
 		String job = "export eCRF data";
 		clickJobTypeSelectOneRadio("tabView:trialjob_form", job);
@@ -167,22 +169,43 @@ public class EcrfDataEntryTest extends SeleniumTestBase implements ProcessorJobO
 				Matcher matcher = FILE_NAME_ID_REGEXP.matcher(getJobOutput("tabView:trialjob_form"));
 				while (matcher.find()) {
 					String fileName = matcher.group(1);
-					String url = getUrl("file?fileid=" + matcher.group(2));
+					String fileId = matcher.group(2);
+					if (!isExportedEcrfFile(fileName)) {
+						info("skipping non-export file '" + fileName + "' (file ID " + fileId + ")");
+						continue;
+					}
+					String url = getUrl("file?fileid=" + fileId);
 					File file = new File(getTestDirectory(), fileName);
 					getChromeDriver().get(url);
-					while (!file.exists()) {
-						Thread.sleep(200);
-					}
+					waitForDownloadedFile(file);
 					info(fileName + " saved");
 					if (CommonUtil.getMimeType(file).equals("application/x-sqlite3")) {
 						exportFile = file.getCanonicalPath();
 					}
 					info("file " + file.getCanonicalPath() + " saved");
 				}
+				if (CommonUtil.isEmptyString(exportFile)) {
+					testFailed("SQLite export file not downloaded");
+				}
 				return;
 			}
 		}
 		testFailed(job + " failed");
+	}
+
+	private static boolean isExportedEcrfFile(String fileName) {
+		String lower = fileName.toLowerCase();
+		return lower.endsWith(".db") || lower.endsWith(".csv") || lower.endsWith(".xlsx") || lower.endsWith(".xls");
+	}
+
+	private void waitForDownloadedFile(File file) throws InterruptedException {
+		long deadline = System.currentTimeMillis() + FILE_DOWNLOAD_TIMEOUT_MS;
+		while (!file.exists()) {
+			if (System.currentTimeMillis() >= deadline) {
+				testFailed("timeout waiting for download of " + file.getName());
+			}
+			Thread.sleep(200);
+		}
 	}
 
 	@Test(description = "Verify exported values found in the SQLite database with the expected values provided by the 'validation' spreadsheet of the eCRF setup (ecrf.xls).")

--- a/web/src/main/webapp/META-INF/includes/inputfield/inputFieldAssociation.xhtml
+++ b/web/src/main/webapp/META-INF/includes/inputfield/inputFieldAssociation.xhtml
@@ -70,8 +70,7 @@
 									<h:outputText value="#{probandListEntryTag.vo.trial.name}" />
 								</p:column>
 								<p:column sortBy="#{probandListEntryTag.vo.trial.department}"
-									filterBy="#{probandListEntryTag.vo.trial.department.id}"
-									filterOptions="#{sessionScopeBean.filterDepartments}">
+									filterBy="#{probandListEntryTag.vo.trial.department.name}">
 									<f:facet name="header">
 										<h:outputText
 											value="#{inputfieldlabels.input_field_association_probandlistentrytag_list_trial_department_column}" />
@@ -211,8 +210,7 @@
 									<h:outputText value="#{inquiry.vo.trial.name}" />
 								</p:column>
 								<p:column sortBy="#{inquiry.vo.trial.department}"
-									filterBy="#{inquiry.vo.trial.department.id}"
-									filterOptions="#{sessionScopeBean.filterDepartments}">
+									filterBy="#{inquiry.vo.trial.department.name}">
 									<f:facet name="header">
 										<h:outputText
 											value="#{inputfieldlabels.input_field_association_inquiry_list_trial_department_column}" />
@@ -400,8 +398,7 @@
 									<h:outputText value="#{ecrfField.vo.trial.name}" />
 								</p:column>
 								<p:column sortBy="#{ecrfField.vo.trial.department}"
-									filterBy="#{ecrfField.vo.trial.department.id}"
-									filterOptions="#{sessionScopeBean.filterDepartments}">
+									filterBy="#{ecrfField.vo.trial.department.name}">
 									<f:facet name="header">
 										<h:outputText
 											value="#{inputfieldlabels.input_field_association_ecrffield_list_trial_department_column}" />

--- a/web/src/main/webapp/META-INF/includes/proband/probandEcrfStatusEntry.xhtml
+++ b/web/src/main/webapp/META-INF/includes/proband/probandEcrfStatusEntry.xhtml
@@ -99,8 +99,7 @@
 							</ui:include>
 						</p:column>
 						<p:column sortBy="#{probandListEntry.vo.trial.department}"
-							filterBy="#{probandListEntry.vo.trial.department.id}"
-							filterOptions="#{sessionScopeBean.filterDepartments}">
+							filterBy="#{probandListEntry.vo.trial.department.name}">
 							<f:attribute name="visibleDefault" value="false" />
 							<f:facet name="header">
 								<h:outputText

--- a/web/src/main/webapp/META-INF/includes/proband/trialParticipation.xhtml
+++ b/web/src/main/webapp/META-INF/includes/proband/trialParticipation.xhtml
@@ -66,8 +66,7 @@
 						</ui:include>
 					</p:column>
 					<p:column sortBy="#{probandListEntry.vo.trial.department}"
-						filterBy="#{probandListEntry.vo.trial.department.id}"
-						filterOptions="#{sessionScopeBean.filterDepartments}">
+						filterBy="#{probandListEntry.vo.trial.department.name}">
 						<f:attribute name="visibleDefault" value="false" />
 						<f:facet name="header">
 							<h:outputText

--- a/web/src/main/webapp/META-INF/includes/shared/bookingDurationSummaryTable.xhtml
+++ b/web/src/main/webapp/META-INF/includes/shared/bookingDurationSummaryTable.xhtml
@@ -145,8 +145,7 @@
 			<p:column
 				rendered="#{showInventory}"
 				sortBy="#{bookingDurationSummaryDetail.vo.inventory.department.name}"
-				filterBy="#{bookingDurationSummaryDetail.vo.inventory.department.id}"
-				filterOptions="#{sessionScopeBean.filterDepartments}">
+				filterBy="#{bookingDurationSummaryDetail.vo.inventory.department.name}">
 				<f:facet name="header">
 					<h:outputText value="#{labels.booking_duration_summary_table_inventory_department_column}" />
 				</f:facet>

--- a/web/src/main/webapp/META-INF/includes/shared/courseSearcher.xhtml
+++ b/web/src/main/webapp/META-INF/includes/shared/courseSearcher.xhtml
@@ -161,8 +161,7 @@
 				</p:column>
 				<p:column
 					sortBy="#{course.vo.department}"
-					filterBy="#{course.vo.department.id}"
-					filterOptions="#{sessionScopeBean.filterDepartments}">
+					filterBy="#{course.vo.department.name}">
 					<f:facet name="header">
 						<h:outputText value="#{courselabels.search_course_result_list_course_department_column}" />
 					</f:facet>

--- a/web/src/main/webapp/META-INF/includes/shared/hyperlink.xhtml
+++ b/web/src/main/webapp/META-INF/includes/shared/hyperlink.xhtml
@@ -84,8 +84,7 @@
 				</p:column>
 				
 				<p:column rendered="#{hyperlinkBean.approval}"
-					filterBy="#{hyperlink.vo.departments}"
-					filterOptions="#{sessionScopeBean.filterDepartments}">
+					filterBy="#{hyperlink.vo.departments.name}">
 					<f:facet name="header">
 						<h:outputText
 							value="#{labels.hyperlink_hyperlink_list_departments_column}" />

--- a/web/src/main/webapp/META-INF/includes/shared/inventorySearcher.xhtml
+++ b/web/src/main/webapp/META-INF/includes/shared/inventorySearcher.xhtml
@@ -161,8 +161,7 @@
 				</p:column>
 				<p:column
 					sortBy="#{inventory.vo.department}"
-					filterBy="#{inventory.vo.department.id}"
-					filterOptions="#{sessionScopeBean.filterDepartments}">
+					filterBy="#{inventory.vo.department.name}">
 					<f:facet name="header">
 						<h:outputText value="#{inventorylabels.search_inventory_result_list_inventory_department_column}" />
 					</f:facet>

--- a/web/src/main/webapp/META-INF/includes/shared/maintenanceItemTableColumns.xhtml
+++ b/web/src/main/webapp/META-INF/includes/shared/maintenanceItemTableColumns.xhtml
@@ -26,8 +26,7 @@
 		</p:column>
 		<p:column
 			sortBy="#{maintenanceItem.vo.inventory.department}"
-			filterBy="#{maintenanceItem.vo.inventory.department.id}"
-			filterOptions="#{sessionScopeBean.filterDepartments}">
+			filterBy="#{maintenanceItem.vo.inventory.department.name}">
 			<f:facet name="header">
 				<h:outputText value="#{inventorylabels.inventorymaintenance_list_inventory_department_column}" />
 			</f:facet>

--- a/web/src/main/webapp/META-INF/includes/shared/massMailSearcher.xhtml
+++ b/web/src/main/webapp/META-INF/includes/shared/massMailSearcher.xhtml
@@ -126,8 +126,7 @@
 					<h:outputText value="#{massMail.vo.name}" />
 				</p:column>
 				<p:column sortBy="#{massMail.vo.department}"
-					filterBy="#{massMail.vo.department.id}"
-					filterOptions="#{sessionScopeBean.filterDepartments}">
+					filterBy="#{massMail.vo.department.name}">
 					<f:facet name="header">
 						<h:outputText
 							value="#{massmaillabels.search_mass_mail_result_list_mass_mail_department_column}" />

--- a/web/src/main/webapp/META-INF/includes/shared/probandSearcher.xhtml
+++ b/web/src/main/webapp/META-INF/includes/shared/probandSearcher.xhtml
@@ -148,8 +148,7 @@
 				</p:column>
 
 				<p:column sortBy="#{proband.vo.department}"
-					filterBy="#{proband.vo.department.id}"
-					filterOptions="#{sessionScopeBean.filterDepartments}">
+					filterBy="#{proband.vo.department.name}">
 					<f:facet name="header">
 						<h:outputText
 							value="#{probandlabels.search_proband_result_list_proband_department_column}" />

--- a/web/src/main/webapp/META-INF/includes/shared/shiftDurationSummaryTable.xhtml
+++ b/web/src/main/webapp/META-INF/includes/shared/shiftDurationSummaryTable.xhtml
@@ -145,8 +145,7 @@
 			<p:column
 				rendered="#{showTrials}"
 				sortBy="#{shiftDurationSummaryDetail.vo.trial.department.name}"
-				filterBy="#{shiftDurationSummaryDetail.vo.trial.department.id}"
-				filterOptions="#{sessionScopeBean.filterDepartments}">
+				filterBy="#{shiftDurationSummaryDetail.vo.trial.department.name}">
 				<f:facet name="header">
 					<h:outputText value="#{labels.shift_duration_summary_table_trial_department_column}" />
 				</f:facet>
@@ -173,8 +172,7 @@
 			<p:column
 				rendered="#{showStaff}"
 				sortBy="#{shiftDurationSummaryDetail.vo.staff.department.name}"
-				filterBy="#{shiftDurationSummaryDetail.vo.staff.department.id}"
-				filterOptions="#{sessionScopeBean.filterDepartments}">
+				filterBy="#{shiftDurationSummaryDetail.vo.staff.department.name}">
 				<f:facet name="header">
 					<h:outputText value="#{labels.shift_duration_summary_table_staff_department_column}" />
 				</f:facet>

--- a/web/src/main/webapp/META-INF/includes/shared/staffSearcher.xhtml
+++ b/web/src/main/webapp/META-INF/includes/shared/staffSearcher.xhtml
@@ -172,8 +172,7 @@
 				</p:column>
 				<p:column
 					sortBy="#{staff.vo.department}"
-					filterBy="#{staff.vo.department.id}"
-					filterOptions="#{sessionScopeBean.filterDepartments}">
+					filterBy="#{staff.vo.department.name}">
 					<f:facet name="header">
 						<h:outputText value="#{stafflabels.search_staff_result_list_staff_department_column}" />
 					</f:facet>

--- a/web/src/main/webapp/META-INF/includes/shared/trialSearcher.xhtml
+++ b/web/src/main/webapp/META-INF/includes/shared/trialSearcher.xhtml
@@ -176,8 +176,7 @@
 				</p:column>
 				<p:column
 					sortBy="#{trial.vo.department}"
-					filterBy="#{trial.vo.department.id}"
-					filterOptions="#{sessionScopeBean.filterDepartments}">
+					filterBy="#{trial.vo.department.name}">
 					<f:facet name="header">
 						<h:outputText value="#{triallabels.search_trial_result_list_trial_department_column}" />
 					</f:facet>

--- a/web/src/main/webapp/META-INF/includes/shared/upcomingCourseTableColumns.xhtml
+++ b/web/src/main/webapp/META-INF/includes/shared/upcomingCourseTableColumns.xhtml
@@ -26,8 +26,7 @@
 		</p:column>
 		<p:column
 			sortBy="#{course.vo.department}"
-			filterBy="#{course.vo.department.id}"
-			filterOptions="#{sessionScopeBean.filterDepartments}">
+			filterBy="#{course.vo.department.name}">
 			<f:facet name="header">
 				<h:outputText value="#{courselabels.admin_upcoming_course_overview_upcomingcourse_list_course_department_column}" />
 			</f:facet>

--- a/web/src/main/webapp/META-INF/includes/shared/userSearcher.xhtml
+++ b/web/src/main/webapp/META-INF/includes/shared/userSearcher.xhtml
@@ -161,8 +161,7 @@
 				</p:column>
 				<p:column
 					sortBy="#{user.vo.department}"
-					filterBy="#{user.vo.department.id}"
-					filterOptions="#{sessionScopeBean.filterDepartments}">
+					filterBy="#{user.vo.department.name}">
 					<f:facet name="header">
 						<h:outputText value="#{userlabels.search_user_result_list_user_department_column}" />
 					</f:facet>
@@ -219,8 +218,7 @@
 					</ui:include>
 				</p:column>
 				<p:column
-					filterBy="#{user.vo.identity.department.id}"
-					filterOptions="#{sessionScopeBean.filterDepartments}">
+					filterBy="#{user.vo.identity.department.name}">
 					<f:facet name="header">
 						<h:outputText value="#{userlabels.search_user_result_list_identity_department_column}" />
 					</f:facet>

--- a/web/src/main/webapp/META-INF/includes/staff/staffAssociation.xhtml
+++ b/web/src/main/webapp/META-INF/includes/staff/staffAssociation.xhtml
@@ -62,8 +62,7 @@
 									<h:outputText value="#{user.vo.name}" />
 								</p:column>
 								<p:column sortBy="#{user.vo.department}"
-									filterBy="#{user.vo.department.id}"
-									filterOptions="#{sessionScopeBean.filterDepartments}">
+									filterBy="#{user.vo.department.name}">
 									<f:facet name="header">
 										<h:outputText
 											value="#{stafflabels.staff_association_account_list_user_department_column}" />
@@ -137,8 +136,7 @@
 									<h:outputText value="#{inventory.vo.name}" />
 								</p:column>
 								<p:column sortBy="#{inventory.vo.department}"
-									filterBy="#{inventory.vo.department.id}"
-									filterOptions="#{sessionScopeBean.filterDepartments}">
+									filterBy="#{inventory.vo.department.name}">
 									<f:facet name="header">
 										<h:outputText
 											value="#{stafflabels.staff_association_ownershipinventory_list_inventory_department_column}" />
@@ -224,8 +222,7 @@
 									<h:outputText value="#{booking.vo.inventory.name}" />
 								</p:column>
 								<p:column sortBy="#{booking.vo.inventory.department}"
-									filterBy="#{booking.vo.inventory.department.id}"
-									filterOptions="#{sessionScopeBean.filterDepartments}">
+									filterBy="#{booking.vo.inventory.department.name}">
 									<f:facet name="header">
 										<h:outputText
 											value="#{stafflabels.staff_association_inventorybooking_list_inventory_department_column}" />
@@ -625,8 +622,7 @@
 									<h:outputText value="#{course.vo.name}" />
 								</p:column>
 								<p:column sortBy="#{course.vo.department}"
-									filterBy="#{course.vo.department.id}"
-									filterOptions="#{sessionScopeBean.filterDepartments}">
+									filterBy="#{course.vo.department.name}">
 									<f:facet name="header">
 										<h:outputText
 											value="#{stafflabels.staff_association_institutioncourses_list_course_department_column}" />
@@ -707,8 +703,7 @@
 									<h:outputText value="#{cvPosition.vo.staff.name}" />
 								</p:column>
 								<p:column sortBy="#{cvPosition.vo.staff.department}"
-									filterBy="#{cvPosition.vo.staff.department.id}"
-									filterOptions="#{sessionScopeBean.filterDepartments}">
+									filterBy="#{cvPosition.vo.staff.department.name}">
 									<f:facet name="header">
 										<h:outputText
 											value="#{stafflabels.staff_association_institutioncvpositions_list_staff_department_column}" />
@@ -825,8 +820,7 @@
 									<h:outputText value="#{lecturer.vo.course.name}" />
 								</p:column>
 								<p:column sortBy="#{lecturer.vo.course.department}"
-									filterBy="#{lecturer.vo.course.department.id}"
-									filterOptions="#{sessionScopeBean.filterDepartments}">
+									filterBy="#{lecturer.vo.course.department.name}">
 									<f:facet name="header">
 										<h:outputText
 											value="#{stafflabels.staff_association_lectures_list_course_department_column}" />
@@ -914,8 +908,7 @@
 									<h:outputText value="#{teamMember.vo.trial.name}" />
 								</p:column>
 								<p:column sortBy="#{teamMember.vo.trial.department}"
-									filterBy="#{teamMember.vo.trial.department.id}"
-									filterOptions="#{sessionScopeBean.filterDepartments}">
+									filterBy="#{teamMember.vo.trial.department.name}">
 									<f:facet name="header">
 										<h:outputText
 											value="#{stafflabels.staff_association_trial_membership_list_trial_department_column}" />
@@ -1058,8 +1051,7 @@
 								</p:column>
 
 								<p:column sortBy="#{proband.vo.department}"
-									filterBy="#{proband.vo.department.id}"
-									filterOptions="#{sessionScopeBean.filterDepartments}">
+									filterBy="#{proband.vo.department.name}">
 									<f:facet name="header">
 										<h:outputText
 											value="#{stafflabels.staff_association_patients_list_proband_department_column}" />

--- a/web/src/main/webapp/META-INF/includes/staff/staffAssociation.xhtml
+++ b/web/src/main/webapp/META-INF/includes/staff/staffAssociation.xhtml
@@ -1056,7 +1056,7 @@
 										<h:outputText
 											value="#{stafflabels.staff_association_patients_list_proband_department_column}" />
 									</f:facet>
-									<h:outputText value="#{course.vo.department.name}" />
+									<h:outputText value="#{proband.vo.department.name}" />
 								</p:column>
 
 								<p:column sortBy="#{proband.vo.category}"

--- a/web/src/main/webapp/META-INF/includes/trial/ecrfFieldStatus.xhtml
+++ b/web/src/main/webapp/META-INF/includes/trial/ecrfFieldStatus.xhtml
@@ -122,8 +122,7 @@
 					</p:column>
 					<p:column
 						sortBy="#{fieldStatusEntry.vo.listEntry.proband.department}"
-						filterBy="#{fieldStatusEntry.vo.listEntry.proband.department.id}"
-						filterOptions="#{sessionScopeBean.filterDepartments}">
+						filterBy="#{fieldStatusEntry.vo.listEntry.proband.department.name}">
 						<f:attribute name="visibleDefault" value="false" />
 						<f:facet name="header">
 							<h:outputText

--- a/web/src/main/webapp/META-INF/includes/trial/probandGroup.xhtml
+++ b/web/src/main/webapp/META-INF/includes/trial/probandGroup.xhtml
@@ -183,8 +183,7 @@
 
 								<p:column
 									sortBy="#{probandListEntry.vo.proband.department.name}"
-									filterBy="#{probandListEntry.vo.proband.department.id}"
-									filterOptions="#{sessionScopeBean.filterDepartments}">
+									filterBy="#{probandListEntry.vo.proband.department.name}">
 									<f:facet name="header">
 										<h:outputText
 											value="#{triallabels.proband_group_probandlistentry_list_proband_department_column}" />

--- a/web/src/main/webapp/META-INF/includes/trial/probandList.xhtml
+++ b/web/src/main/webapp/META-INF/includes/trial/probandList.xhtml
@@ -136,8 +136,7 @@
 						</p:column>
 
 						<p:column sortBy="#{probandListEntry.vo.proband.department}"
-							filterBy="#{probandListEntry.vo.proband.department.id}"
-							filterOptions="#{sessionScopeBean.filterDepartments}">
+							filterBy="#{probandListEntry.vo.proband.department.name}">
 							<f:attribute name="visibleDefault" value="false" />
 							<f:facet name="header">
 								<h:outputText

--- a/web/src/main/webapp/META-INF/includes/trial/reimbursements.xhtml
+++ b/web/src/main/webapp/META-INF/includes/trial/reimbursements.xhtml
@@ -344,8 +344,7 @@
 
 
 						<p:column sortBy="#{summary.vo.department}"
-							filterBy="#{summary.vo.department.id}"
-							filterOptions="#{sessionScopeBean.filterDepartments}">
+							filterBy="#{summary.vo.department.name}">
 							<f:facet name="header">
 								<h:outputText
 									value="#{triallabels.reimbursements_proband_money_transfer_no_participation_summary_list_proband_department_column}" />

--- a/web/src/main/webapp/META-INF/includes/trial/teamMember.xhtml
+++ b/web/src/main/webapp/META-INF/includes/trial/teamMember.xhtml
@@ -93,8 +93,7 @@
 					</p:column>
 
 					<p:column sortBy="#{teamMember.vo.staff.department}"
-						filterBy="#{teamMember.vo.staff.department.id}"
-						filterOptions="#{sessionScopeBean.filterDepartments}">
+						filterBy="#{teamMember.vo.staff.department.name}">
 						<f:attribute name="visibleDefault" value="false" />
 						<f:facet name="header">
 							<h:outputText

--- a/web/src/main/webapp/META-INF/includes/trial/trialAssociation.xhtml
+++ b/web/src/main/webapp/META-INF/includes/trial/trialAssociation.xhtml
@@ -93,8 +93,7 @@
 									<h:outputText value="#{course.vo.name}" />
 								</p:column>
 								<p:column sortBy="#{course.vo.department}"
-									filterBy="#{course.vo.department.id}"
-									filterOptions="#{sessionScopeBean.filterDepartments}">
+									filterBy="#{course.vo.department.name}">
 									<f:facet name="header">
 										<h:outputText
 											value="#{triallabels.trial_association_courses_list_course_department_column}" />
@@ -187,8 +186,7 @@
 									<h:outputText value="#{massMail.vo.name}" />
 								</p:column>
 								<p:column sortBy="#{massMail.vo.department}"
-									filterBy="#{massMail.vo.department.id}"
-									filterOptions="#{sessionScopeBean.filterDepartments}">
+									filterBy="#{massMail.vo.department.name}">
 									<f:facet name="header">
 										<h:outputText
 											value="#{triallabels.trial_association_massmails_list_mass_mail_department_column}" />

--- a/web/src/main/webapp/META-INF/includes/trial/trialEcrfStatusEntry.xhtml
+++ b/web/src/main/webapp/META-INF/includes/trial/trialEcrfStatusEntry.xhtml
@@ -149,8 +149,7 @@
 						</p:column>
 
 						<p:column sortBy="#{probandListEntry.vo.proband.department}"
-							filterBy="#{probandListEntry.vo.proband.department.id}"
-							filterOptions="#{sessionScopeBean.filterDepartments}">
+							filterBy="#{probandListEntry.vo.proband.department.name}">
 							<f:attribute name="visibleDefault" value="false" />
 							<f:facet name="header">
 								<h:outputText

--- a/web/src/main/webapp/course/adminExpiringParticipationOverview.xhtml
+++ b/web/src/main/webapp/course/adminExpiringParticipationOverview.xhtml
@@ -117,8 +117,7 @@
 							</ui:include>
 						</p:column>
 						<p:column sortBy="#{statusEntry.vo.staff.department}"
-							filterBy="#{statusEntry.vo.staff.department.id}"
-							filterOptions="#{sessionScopeBean.filterDepartments}">
+							filterBy="#{statusEntry.vo.staff.department.name}">
 							<f:facet name="header">
 								<h:outputText
 									value="#{courselabels.admin_expiring_participation_overview_expiringparticipation_list_staff_department_column}" />

--- a/web/src/main/webapp/course/expiringCourseOverview.xhtml
+++ b/web/src/main/webapp/course/expiringCourseOverview.xhtml
@@ -107,8 +107,7 @@
 							<h:outputText value="#{course.vo.name}" />
 						</p:column>
 						<p:column sortBy="#{course.vo.department}"
-							filterBy="#{course.vo.department.id}"
-							filterOptions="#{sessionScopeBean.filterDepartments}">
+							filterBy="#{course.vo.department.name}">
 							<f:facet name="header">
 								<h:outputText
 									value="#{courselabels.expiring_course_overview_expiringcourse_list_course_department_column}" />

--- a/web/src/main/webapp/inventory/inventoryStatusOverview.xhtml
+++ b/web/src/main/webapp/inventory/inventoryStatusOverview.xhtml
@@ -120,8 +120,7 @@
 						</p:column>
 						<p:column
 							sortBy="#{statusEntry.vo.inventory.department}"
-							filterBy="#{statusEntry.vo.inventory.department.id}"
-							filterOptions="#{sessionScopeBean.filterDepartments}">
+							filterBy="#{statusEntry.vo.inventory.department.name}">
 							<f:facet name="header">
 								<h:outputText value="#{inventorylabels.inventory_status_overview_inventorystatus_list_inventory_department_column}" />
 							</f:facet>

--- a/web/src/main/webapp/proband/autoDeletionProbandOverview.xhtml
+++ b/web/src/main/webapp/proband/autoDeletionProbandOverview.xhtml
@@ -115,8 +115,7 @@
 								</ui:include>
 							</p:column>
 							<p:column sortBy="#{proband.vo.department}"
-								filterBy="#{proband.vo.department.id}"
-								filterOptions="#{sessionScopeBean.filterDepartments}">
+								filterBy="#{proband.vo.department.name}">
 								<f:facet name="header">
 									<h:outputText
 										value="#{probandlabels.auto_deletion_proband_overview_autodeletionproband_list_proband_department_column}" />

--- a/web/src/main/webapp/proband/probandStatusOverview.xhtml
+++ b/web/src/main/webapp/proband/probandStatusOverview.xhtml
@@ -140,8 +140,7 @@
 						
 						<p:column
 							sortBy="#{statusEntry.vo.proband.department}"
-							filterBy="#{statusEntry.vo.proband.department.id}"
-							filterOptions="#{sessionScopeBean.filterDepartments}">
+							filterBy="#{statusEntry.vo.proband.department.name}">
 							<f:facet name="header">
 								<h:outputText value="#{probandlabels.proband_status_overview_probandstatus_list_proband_department_column}" />
 							</f:facet>

--- a/web/src/main/webapp/staff/expiringParticipationOverview.xhtml
+++ b/web/src/main/webapp/staff/expiringParticipationOverview.xhtml
@@ -110,8 +110,7 @@
 							<h:outputText value="#{statusEntry.vo.course.name}" />
 						</p:column>
 						<p:column sortBy="#{statusEntry.vo.course.department}"
-							filterBy="#{statusEntry.vo.course.id}"
-							filterOptions="#{sessionScopeBean.filterDepartments}">
+							filterBy="#{statusEntry.vo.course.department.name}">
 							<f:facet name="header">
 								<h:outputText
 									value="#{stafflabels.expiring_participation_overview_expiringparticipation_list_course_department_column}" />

--- a/web/src/main/webapp/staff/staffStatusOverview.xhtml
+++ b/web/src/main/webapp/staff/staffStatusOverview.xhtml
@@ -120,8 +120,7 @@
 						</p:column>
 						<p:column
 							sortBy="#{statusEntry.vo.staff.department}"
-							filterBy="#{statusEntry.vo.staff.department.id}"
-							filterOptions="#{sessionScopeBean.filterDepartments}">
+							filterBy="#{statusEntry.vo.staff.department.name}">
 							<f:facet name="header">
 								<h:outputText value="#{stafflabels.staff_status_overview_staffstatus_list_staff_department_column}" />
 							</f:facet>

--- a/web/src/main/webapp/trial/timelineEventOverview.xhtml
+++ b/web/src/main/webapp/trial/timelineEventOverview.xhtml
@@ -149,8 +149,7 @@
 							</p:column>
 							<p:column
 								sortBy="#{timelineEvent.vo.trial.department}"
-								filterBy="#{timelineEvent.vo.trial.department.id}"
-								filterOptions="#{sessionScopeBean.filterDepartments}">
+								filterBy="#{timelineEvent.vo.trial.department.name}">
 								<f:facet name="header">
 									<h:outputText value="#{triallabels.timeline_event_overview_timelineevent_list_trial_department_column}" />
 								</f:facet>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Department filters now support localized and translated names.
  - Free-text department searching is available across search results, summaries, and status tables.
  - Searches support case-insensitive and partial-name matching.

- **UI Updates**
  - Department columns now filter by name instead of department ID.
  - Predefined department dropdowns have been replaced with text-based filtering.

- **Bug Fixes**
  - Corrected the department displayed for patients in staff association tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->