### PR TITLE
ci: update checkout to v7, cache to v6, setup-maven to v5.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build and Analyze
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 11
@@ -24,11 +24,11 @@ jobs:
 #        with:
 #          java-version: 11
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v4.5
+        uses: stCarolas/setup-maven@v5.1
         with:
           maven-version: 3.8.7
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK
@@ -26,11 +26,11 @@ jobs:
 #        with:
 #          java-version: 11
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v4.5
+        uses: stCarolas/setup-maven@v5.1
         with:
           maven-version: 3.8.7
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
Updates the build and test workflows to current action versions.

Changes:
- actions/checkout v3 -> v7
- actions/cache v3 -> v6
- stCarolas/setup-maven v4.5 -> v5.1

Reason: checkout v3, cache v3, and setup-maven v4.5 run on deprecated Node runtimes. GitHub deprecated Node 20 on hosted runners and the older majors run on Node 16 or 20 (https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). setup-maven v5.1 is the node24 release. Inputs used by these workflows (cache path/key/restore-keys, maven version) are unchanged across the bumped versions.

Validation: YAML parses locally (python yaml.safe_load); workflow steps unchanged.

Note: this is a fork PR, so first-time workflow runs may wait for maintainer approval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build and test workflows to use newer versions of their supporting actions.
  * Continued using Maven 3.8.7 for consistent project builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->