### PR TITLE
Disable GSS and SSL probes on the local PostgreSQL JDBC URL

### DIFF
--- a/core/src/exec/resources/c3p0.properties
+++ b/core/src/exec/resources/c3p0.properties
@@ -1,0 +1,5 @@
+# Fail checkout after 30s instead of waiting forever when Postgres is saturated.
+# ComboPooledDataSource XML does not set these; c3p0.properties supplies the defaults.
+c3p0.checkoutTimeout=30000
+c3p0.idleConnectionTestPeriod=60
+c3p0.preferredTestQuery=SELECT 1

--- a/core/src/main/resources/ctsms-applicationcontext.properties
+++ b/core/src/main/resources/ctsms-applicationcontext.properties
@@ -1,7 +1,9 @@
 
 database_username=ctsms
 database_password=ctsms
-database_connection_url=jdbc:postgresql://localhost/ctsms
+# pgjdbc 42.7.x defaults (sslmode=prefer, gssEncMode=prefer) open extra sockets per
+# acquire; disable both for local Postgres to avoid accept-queue connection refused.
+database_connection_url=jdbc:postgresql://localhost/ctsms?sslmode=disable&gssEncMode=disable
 c3p0.acquireIncrement=3
 c3p0.initialPoolSize=10
 c3p0.minPoolSize=5

--- a/core/src/test/resources/applicationContext-localTestDataSource.xml
+++ b/core/src/test/resources/applicationContext-localTestDataSource.xml
@@ -22,7 +22,7 @@
 			value="ctsms" />
 		<property
 			name="url"
-			value="jdbc:postgresql://localhost/ctsms_test" /> 
+			value="jdbc:postgresql://localhost/ctsms_test?sslmode=disable&amp;gssEncMode=disable" /> 
 	</bean>
 	<!-- (local) Transaction Manager -->
 	<bean

--- a/pom.xml
+++ b/pom.xml
@@ -731,10 +731,10 @@
 					For DB2 use: jdbc:db2:ctsms For Informix use: jdbc:informix-sqli://localhost:1557/ctsms:INFORMIXSERVER=myserver
 					For MSSQL use: jdbc:microsoft:sqlserver://localhost:1433;DatabaseName=ctsms
 					For Pointbase use: jdbc:pointbase:server://@pointbase.server@:@pointbase.port/pointbase.ctsms@,new
-					For Postgres use: jdbc:postgresql://localhost/ctsms For Sybase use: jdbc:sybase:Tds:localhost:5000/ctsms?JCONNECT_VERSION=6
+					For Postgres use: jdbc:postgresql://localhost/ctsms?sslmode=disable&amp;gssEncMode=disable For Sybase use: jdbc:sybase:Tds:localhost:5000/ctsms?JCONNECT_VERSION=6
 					For SapDB use: jdbc:sapdb://127.0.0.1/ctsms For Progress use: jdbc:JdbcProgress:T:localhost:3305:ctsms -->
 				<jdbc.url>
-					jdbc:postgresql://localhost/ctsms
+					jdbc:postgresql://localhost/ctsms?sslmode=disable&amp;gssEncMode=disable
 				</jdbc.url>
 				<!-- Enter id/password for the database connection -->
 				<jdbc.username>

--- a/web/src/main/resources/c3p0.properties
+++ b/web/src/main/resources/c3p0.properties
@@ -1,0 +1,5 @@
+# Fail checkout after 30s instead of waiting forever when Postgres is saturated.
+# ComboPooledDataSource XML does not set these; c3p0.properties supplies the defaults.
+c3p0.checkoutTimeout=30000
+c3p0.idleConnectionTestPeriod=60
+c3p0.preferredTestQuery=SELECT 1


### PR DESCRIPTION
## Summary
- Point the local JDBC URL at `sslmode=disable&gssEncMode=disable` so pgjdbc 42.7.x does not open extra GSS/SSL sockets per c3p0 acquire.
- That extra handshake is what filled the postmaster accept queue during the GIRO eCRF importer and showed up as `Connection to localhost:5432 refused` plus c3p0 APPARENT DEADLOCK.
- Add c3p0 checkout timeout and idle connection tests so waiters fail in 30s instead of wedging the pool.

## Test plan
- [ ] Redeploy / restart Tomcat so it picks up `database_connection_url` (and `/ctsms/properties` overlay if present).
- [ ] Confirm Postgres is listening: `ss -ltnp | grep 5432` or `netstat -ano | findstr 5432`.
- [ ] Start the GIRO hyf eCRF importer and watch that localhost:5432 stays accepted under load.
- [ ] Confirm the app still logs in and reads/writes eCRF data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection reliability by preventing indefinite waits when PostgreSQL connections are unavailable.
  * Added periodic connection validation to help identify stale or unusable connections.
  * Updated local database connections to avoid SSL and GSS encryption negotiation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->